### PR TITLE
differentiate between overtaking cars and bikes

### DIFF
--- a/lib/sensors/overtaking_prediction_sensor.dart
+++ b/lib/sensors/overtaking_prediction_sensor.dart
@@ -1,3 +1,4 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/blocs/geolocation_bloc.dart';
 import 'package:sensebox_bike/sensors/sensor.dart';
@@ -7,7 +8,8 @@ import 'package:sensebox_bike/ui/widgets/sensor/sensor_card.dart';
 import 'package:sensebox_bike/utils/sensor_utils.dart';
 
 class OvertakingPredictionSensor extends Sensor {
-  List<double> _latestPrediction = [0.0];
+  double _latestCarPrediction = 0.0;
+  double _latestBikePrediction = 0.0;
 
   @override
   get uiPriority => 40;
@@ -24,40 +26,123 @@ class OvertakingPredictionSensor extends Sensor {
   void onDataReceived(List<double> data) {
     super.onDataReceived(data); // Call the parent class to handle buffering
     if (data.isNotEmpty) {
-      _latestPrediction =
-          data; // Assuming the first value is the prediction score
+      _latestCarPrediction = data[0];
+      _latestBikePrediction = data[1];
     }
   }
 
   @override
   List<double> aggregateData(List<List<double>> valueBuffer) {
-    List<double> myValues = valueBuffer.map((e) => e[0]).toList();
-    // Example aggregation logic: calculating the mean prediction score
-    return [myValues.reduce((a, b) => a + b) / myValues.length];
+    List<double> sumValues = [0.0, 0.0, 0.0];
+    int count = valueBuffer.length;
+
+    for (var values in valueBuffer) {
+      sumValues[0] += values[0];
+      sumValues[1] += values[1];
+      sumValues[1] += 1.0 - values[0] - values[1];
+    }
+
+    // Calculate the mean for asphalt, compacted, paving, sett, and standing
+    return sumValues.map((value) => value / count).toList();
+  }
+
+  Widget _buildLegendEntry(
+      String title, Color color, double value, BuildContext context) {
+    return Row(children: [
+      Container(
+        height: 16,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: color,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 0.5),
+          child: Text(value.toStringAsFixed(1),
+              style: Theme.of(context).textTheme.labelSmall),
+        ),
+      ),
+      const SizedBox(width: 8),
+      Text(title)
+    ]);
   }
 
   @override
   Widget buildWidget() {
     return StreamBuilder<List<double>>(
-      stream: valueStream,
-      initialData: _latestPrediction,
+      stream: valueStream
+          .map((event) => [event[0], event[1], event[2], event[3], event[4]]),
+      initialData: [
+        _latestCarPrediction,
+        _latestBikePrediction,
+      ],
       builder: (context, snapshot) {
-        double displayValue = snapshot.data?[0] ?? _latestPrediction[0];
-
+        List<double> displayValues = snapshot.data ??
+            [
+              _latestCarPrediction,
+              _latestBikePrediction,
+            ];
         return SensorCard(
             title: "Overtaking",
             icon: getSensorIcon(title),
             color: getSensorColor(title),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.baseline,
-              textBaseline: TextBaseline.alphabetic,
+            child: Column(
               children: [
-                Text(
-                  displayValue.toStringAsFixed(1),
-                  style: const TextStyle(fontSize: 48),
+                const SizedBox(
+                  height: 2,
                 ),
-                const Text(
-                  '%',
+                for (int i = 0; i < displayValues.length; i++)
+                  _buildLegendEntry(
+                      ["Car", "Bike"][i],
+                      [
+                        Colors.red,
+                        Colors.blue,
+                      ][i],
+                      displayValues[i],
+                      context),
+                SizedBox(
+                  width: double.infinity,
+                  height: 18,
+                  child: RotatedBox(
+                    quarterTurns: 1,
+                    child: BarChart(BarChartData(
+                      borderData: FlBorderData(show: false),
+                      barTouchData: BarTouchData(enabled: false),
+                      gridData: const FlGridData(show: false),
+                      titlesData: const FlTitlesData(show: false),
+                      barGroups: [
+                        BarChartGroupData(
+                          x: 0,
+                          barRods: [
+                            BarChartRodData(
+                              toY: 1,
+                              rodStackItems: [
+                                for (int i = 0; i < displayValues.length; i++)
+                                  BarChartRodStackItem(
+                                    displayValues
+                                        .take(i)
+                                        .fold(0.0, (a, b) => a + b),
+                                    displayValues
+                                        .take(i + 1)
+                                        .fold(0.0, (a, b) => a + b),
+                                    [
+                                      Colors.red,
+                                      Colors.blue,
+                                    ][i],
+                                  ),
+                                BarChartRodStackItem(
+                                  displayValues
+                                      .take(displayValues.length)
+                                      .fold(0.0, (a, b) => a + b),
+                                  1.0,
+                                  Colors.white,
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ],
+                    )),
+                  ),
                 ),
               ],
             ));

--- a/lib/services/opensensemap_service.dart
+++ b/lib/services/opensensemap_service.dart
@@ -306,61 +306,68 @@ class OpenSenseMapService {
       {
         "id": "6",
         "icon": 'osem-shock',
-        "title": 'Overtaking Manoeuvre',
+        "title": 'Overtaking Car',
         "unit": '%',
         "sensorType": 'VL53L8CX'
       },
       {
         "id": "7",
         "icon": 'osem-shock',
+        "title": 'Overtaking Bike',
+        "unit": '%',
+        "sensorType": 'VL53L8CX'
+      },
+      {
+        "id": "8",
+        "icon": 'osem-shock',
         "title": 'Overtaking Distance',
         "unit": 'cm',
         "sensorType": 'VL53L8CX'
       },
       {
-        "id": "8",
+        "id": "9",
         "icon": 'osem-shock',
         "title": 'Surface Asphalt',
         "unit": '%',
         "sensorType": 'MPU-6050'
       },
       {
-        "id": "9",
+        "id": "10",
         "icon": 'osem-shock',
         "title": 'Surface Sett',
         "unit": '%',
         "sensorType": 'MPU-6050'
       },
       {
-        "id": "10",
+        "id": "11",
         "icon": 'osem-shock',
         "title": 'Surface Compacted',
         "unit": '%',
         "sensorType": 'MPU-6050'
       },
       {
-        "id": "11",
+        "id": "12",
         "icon": 'osem-shock',
         "title": 'Surface Paving',
         "unit": '%',
         "sensorType": 'MPU-6050'
       },
       {
-        "id": "12",
+        "id": "13",
         "icon": 'osem-shock',
         "title": 'Standing',
         "unit": '%',
         "sensorType": 'MPU-6050'
       },
       {
-        "id": "13",
+        "id": "14",
         "icon": 'osem-shock',
         "title": 'Surface Anomaly',
         "unit": 'Δ',
         "sensorType": 'MPU-6050'
       },
       {
-        "id": "14",
+        "id": "15",
         "icon": 'osem-dashboard',
         "title": 'Speed',
         "unit": 'm/s',

--- a/lib/ui/screens/track_detail_screen.dart
+++ b/lib/ui/screens/track_detail_screen.dart
@@ -254,6 +254,7 @@ class _TrackDetailScreenState extends State<TrackDetailScreen> {
                       'humidity',
                       'distance',
                       'overtaking',
+                      'overtaking_bike',
                       'surface_classification_asphalt',
                       'surface_classification_compacted',
                       'surface_classification_paving',

--- a/lib/utils/sensor_utils.dart
+++ b/lib/utils/sensor_utils.dart
@@ -21,8 +21,10 @@ String? getTitleFromSensorKey(String key, String? attribute) {
       return 'Finedust PM1';
     case 'distance':
       return 'Overtaking Distance';
-    case 'overtaking':
-      return 'Overtaking Manoeuvre';
+    case 'overtaking_car':
+      return 'Overtaking Car';
+    case 'overtaking_bike':
+      return 'Overtaking Bike';
     case 'surface_classification_asphalt':
       return 'Surface Asphalt';
     case 'surface_classification_sett':


### PR DESCRIPTION
![Screenshot_2024-10-17-15-52-10-464_de reedu senseboxbike-edit](https://github.com/user-attachments/assets/31e42612-bdbd-40d4-a0d9-525e2a47cd93)

Note: this makes it not compatible with the current atrai senseBox:bikes on the OSM, cause its registered as an additional sensor. Maybe also allow senseBox:bikes without an "Overtaking Bike" Sensor.

Also idk if the visualization is good or the icon should be changed.