### PR TITLE
Feat: remove anomaly sensor

### DIFF
--- a/lib/blocs/sensor_bloc.dart
+++ b/lib/blocs/sensor_bloc.dart
@@ -1,5 +1,6 @@
 // File: lib/blocs/sensor_bloc.dart
 import 'package:sensebox_bike/blocs/geolocation_bloc.dart';
+import 'package:sensebox_bike/feature_flags.dart';
 import 'package:sensebox_bike/sensors/acceleration_sensor.dart';
 import 'package:sensebox_bike/sensors/distance_sensor.dart';
 import 'package:sensebox_bike/sensors/finedust_sensor.dart';
@@ -71,6 +72,11 @@ class SensorBloc with ChangeNotifier {
 
     // get all sensors with this characteristic
     for (var sensor in _sensors) {
+      // Check if the sensor should be excluded based on the feature flag
+      if (FeatureFlags.hideSurfaceAnomalySensor &&
+          sensor is SurfaceAnomalySensor) {
+        continue;
+      }
       if (availableCharacteristics
           .map((e) => e.uuid.toString())
           .contains(sensor.characteristicUuid)) {

--- a/lib/feature_flags.dart
+++ b/lib/feature_flags.dart
@@ -1,0 +1,3 @@
+class FeatureFlags {
+  static bool hideSurfaceAnomalySensor = true; // Default is off
+}

--- a/lib/ui/screens/track_detail_screen.dart
+++ b/lib/ui/screens/track_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:sensebox_bike/feature_flags.dart';
 import 'package:sensebox_bike/models/sensor_data.dart';
 import 'package:sensebox_bike/models/track_data.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
@@ -248,6 +249,12 @@ class _TrackDetailScreenState extends State<TrackDetailScreen> {
                             MapEntry(e[0], e[1] == 'null' ? null : e[1])),
                       );
                     }).toList();
+
+                    // Filter out surface_anomaly if the feature flag is enabled
+                    if (FeatureFlags.hideSurfaceAnomalySensor) {
+                      sensorTitles.removeWhere(
+                          (sensor) => sensor['title'] == 'surface_anomaly');
+                    }
 
                     List<String> order = [
                       'temperature',

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,5 +1,6 @@
 import 'package:mocktail/mocktail.dart';
 import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
+import 'package:sensebox_bike/models/sensor_data.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/services/isar_service/geolocation_service.dart';
 import 'package:sensebox_bike/services/isar_service/isar_provider.dart';
@@ -25,3 +26,5 @@ class MockOpenSenseMapBloc extends OpenSenseMapBloc {
     isAuthenticated = false;
   }
 }
+
+class FakeSensorData extends Fake implements SensorData {}

--- a/test/services/isar_service/sensor_service_test.dart
+++ b/test/services/isar_service/sensor_service_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sensebox_bike/feature_flags.dart';
+import 'package:sensebox_bike/models/sensor_data.dart';
+import '../../mocks.dart';
+
+void main() {
+  late MockIsarService mockIsarService;
+  late MockSensorService mockSensorService;
+
+  setUpAll(() {
+    // Register a fallback value for SensorData
+    registerFallbackValue(FakeSensorData());
+  });
+
+  setUp(() {
+    mockIsarService = MockIsarService();
+    mockSensorService = MockSensorService();
+
+    // Mock the sensorService in IsarService
+    when(() => mockIsarService.sensorService).thenReturn(mockSensorService);
+
+    // Mock the saveSensorData method to return a Future<int>
+    when(() => mockSensorService.saveSensorData(any()))
+        .thenAnswer((_) async => 1);
+  });
+
+  test('should store data for SurfaceAnomalySensor when feature flag is enabled', () async {
+    // Arrange
+    FeatureFlags.hideSurfaceAnomalySensor = true; // Enable the feature flag
+    final sensorData = SensorData()
+      ..title = 'surface_anomaly'
+      ..value = 1.23
+      ..attribute = 'anomaly_level';
+
+    // Act
+    await mockSensorService.saveSensorData(sensorData);
+
+    // Assert
+    final capturedData =
+        verify(() => mockSensorService.saveSensorData(captureAny()))
+            .captured
+            .single as SensorData;
+
+    // Verify the captured data
+    expect(capturedData.title, 'surface_anomaly');
+    expect(capturedData.value, 1.23);
+    expect(capturedData.attribute, 'anomaly_level');
+  });
+}


### PR DESCRIPTION
Closes #27 
Closes #26 (duplicate)

Hides SurfaceAnomalySensor widget

### Detailed Changes
*   Adds FeatureFlags class
*   If flag is on, hides
    *  SurfaceAnomalySensor widget from Home screen
    *  Surface anamaly box from TrackDetails screen
Open questions:
1. Flag management (if needed)
- we could allow user disabling flag from settings screen.
- we could load a config file with flags from again gh repo, for example, on app start. This way we could manage this flag remotely.
2. I don't hide anything else behind the flag. Should I disregard this sensor at all?

### Testing
If the flag is on, no data is displayed on home screen, when senseBox is connected.

### Checklist before requesting a review

[X] I have performed a self-review of my code
[ ] I have added or updated relevant documentation
[X] Add tests

### Additional Information
<img src="https://github.com/user-attachments/assets/b75b3dca-5f28-4bee-b96d-45f592dae90d" alt="image" width="300" />
<img src="https://github.com/user-attachments/assets/327655be-3c0e-4b56-a312-b88267f05d32" alt="image" width="300" />