### PR TITLE
hotfix: exception about mismatching zones

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: ".env", mergeWith: Platform.environment);
 
   await SentryFlutter.init(
@@ -34,7 +35,6 @@ void main() async {
     },
     //appRunner: () => runApp(const SenseBoxBikeApp()),
     appRunner: () => runZonedGuarded(() {
-      WidgetsFlutterBinding.ensureInitialized();
       // Error handlers
       FlutterError.onError = (details) {
         if (!kDebugMode) {


### PR DESCRIPTION
Closes #

Should fix this [exception](https://reedu-0b.sentry.io/issues/6567771970/?project=4507900545990656&query=is%3Aunresolved%20release%3Ade.reedu.senseboxbike%403.2.0%2B320&referrer=issue-stream&stream_index=0)

### Detailed Changes
Move WidgetsFlutterBinding.ensureInitialized(); before first async call

### Testing
On main, when you start android app (i think it should be visible if you ran emulator), you should see the following info reported by flutter.

```
I/flutter (15344): Zone mismatch.
I/flutter (15344): The Flutter bindings were initialized in a different zone than is now being used. This will likely cause confusion and bugs as any zone-specific configuration will inconsistently use the configuration of the original binding initialization zone or this zone based on hard-to-predict factors such as which zone was active when a particular callback was set.
I/flutter (15344): It is important to use the same zone when calling ensureInitialized on the binding as when calling runApp later.
I/flutter (15344): To make this warning fatal, set BindingBase.debugZoneErrorsAreFatal to true before the bindings are initialized (i.e. as the first statement in void main() { }).
I/flutter (15344): #0 BindingBase.debugCheckZone.<anonymous closure> (package:flutter/src/foundation/binding.dart:519:31)
I/flutter (15344): #1 BindingBase.debugCheckZone (package:flutter/src/foundation/binding.dart:525:6)
I/flutter (15344): #2 _runWidget (package:flutter/src/widgets/binding.dart:1544:18)
I/flutter (15344): #3 runApp (package:flutter/src/widgets/binding.dart:1480:3)
I/flutter (15344): #4 main.<anonymous closure>.<anonymous closure> (package:sensebox_bike/main.dart:54:7)
I/flutter (15344): #9 main.<anonymous closure> (package:sensebox_bike/main.dart:36:22)
I/flutter (15344): #10 Sentry._init (package:sentry/src/sentry.dart:176:24)
I/flutter (15344): <asynchronous suspension>
I/flutter (15344): #11 Sentry.init (package:sentry/src/sentry.dart:83:5)
I/flutter (15344): <asynchronous suspension>
I/flutter (15344): #12 SentryFlutter.init (package:sentry_flutter/src/sentry_flutter.dart:96:5)
```

On the current branch you shouldn't see this message.

### Checklist before requesting a review

[ ] I have performed a self-review of my code
[ ] I have added or updated relevant documentation

### Additional Information
🤦🏽 
