### PR TITLE
Chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[dependabot]"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "flutter"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    commit-message:
+      prefix: "[dependabot]"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+    commit-message:
+      prefix: "[dependabot]"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,15 +19,3 @@ updates:
     commit-message:
       prefix: "[dependabot]"
     open-pull-requests-limit: 5
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
-    commit-message:
-      prefix: "[dependabot]"
-    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     commit-message:
       prefix: "[dependabot]"
     open-pull-requests-limit: 5
-  - package-ecosystem: "flutter"
+  - package-ecosystem: "pub"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Closes #62 

Configure dependabot

### Detailed Changes

*   Place dependabot.yml under .github
*   Configure the following
    - dependabot check for gh actions and flutter
    - set cycle to weekly and limit of open prs to 5, so that we're not overwhelmed by open prs
    - suggest grouping of dependency updates for dev and production.

### Testing

Once this PR is merged into main, dependabot will run next Monday (this is default run time).

### Checklist before requesting a review

[x] I have performed a self-review of my code
[ ] I have added or updated relevant documentation

### Additional Information
- https://baimamboukar.medium.com/keeping-your-flutter-app-dependencies-always-up-to-date-with-github-dependabot-35e9d19a9d3a
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
- https://chromium.googlesource.com/external/github.com/flutter/packages/+/refs/tags/google_sign_in_ios-v5.8.1/.github/dependabot.yml
