### PR TITLE
Feat: add privacy policy consent

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -5,6 +5,13 @@ const retryPeriod = 2; // in minutes
 const premanentConnectivityFalurePeriod = 20; // in minutes
 const defaultTimeout = 30; // in seconds
 
+class SharedPreferencesKeys {
+  static const String privacyPolicyAcceptedAt = 'privacyPolicyAcceptedAt';
+  static const String privacyZones = 'privacyZones';
+  static const String selectedSenseBox = 'selectedSenseBox';
+  static const bool vibrateOnDisconnect = false;
+}
+
 const openSenseMapUrl = 'https://api.opensensemap.org';
 const senseBoxBikePrivacyPolicyUrl =
     'https://sensebox.de/sensebox-bike-privacy-policy';

--- a/lib/feature_flags.dart
+++ b/lib/feature_flags.dart
@@ -1,3 +1,4 @@
 class FeatureFlags {
   static bool hideSurfaceAnomalySensor = true; // Default is off
+  static bool showPrivacyPolicyScreen = false; // Default is off
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -167,5 +167,6 @@
     "accountManagement": "Kontoverwaltung",
     "deleteAllHint": "Dies löscht alle Ihre Tracks aus der App.",
     "generalConfirmation": "Bestätigung",
-    "privacyPolicyAccept": "Ich akzeptiere die Datenschutzerklärung"
+    "privacyPolicyAccept": "Ich akzeptiere die Datenschutzerklärung",
+    "scrollToAcceptHint": "Bitte lesen Sie die Datenschutzerklärung und akzeptieren Sie sie, um die App weiterhin nutzen zu können."
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -45,6 +45,7 @@
     "generalLogin": "Anmelden",
     "generalLogout": "Abmelden",
     "generalRegister": "Registrieren",
+    "generalProceed": "Fortfahren",
     "homeBottomBarHome": "Start",
     "homeBottomBarTracks": "Tracks",
     "tracksAppBarTitle": "Tracks",
@@ -165,6 +166,6 @@
     "settingsDeleteAllDataError": "Fehler beim Löschen aller Daten. Bitte versuchen Sie es erneut.",
     "accountManagement": "Kontoverwaltung",
     "deleteAllHint": "Dies löscht alle Ihre Tracks aus der App.",
-    "generalConfirmation": "Bestätigung"
-
+    "generalConfirmation": "Bestätigung",
+    "privacyPolicyAccept": "Ich akzeptiere die Datenschutzerklärung"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -167,6 +167,5 @@
     "accountManagement": "Kontoverwaltung",
     "deleteAllHint": "Dies löscht alle Ihre Tracks aus der App.",
     "generalConfirmation": "Bestätigung",
-    "privacyPolicyAccept": "Ich akzeptiere die Datenschutzerklärung",
-    "scrollToAcceptHint": "Bitte lesen Sie die Datenschutzerklärung und akzeptieren Sie sie, um die App weiterhin nutzen zu können."
+    "privacyPolicyAccept": "Ich habe die Datenschutzerklärung gelesen und stimme ihr zu."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -167,6 +167,7 @@
     "accountManagement": "Account Management",
     "deleteAllHint": "This will delete all your tracks from the app.",
     "generalConfirmation": "Confirmation",
-    "privacyPolicyAccept": "I accept the Privacy Policy"
+    "privacyPolicyAccept": "I accept the Privacy Policy",
+    "scrollToAcceptHint": "Please review and accept the Privacy Policy to continue using the app."
 
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -45,6 +45,7 @@
     "generalLogin": "Login",
     "generalLogout": "Logout",
     "generalRegister": "Register",
+    "generalProceed": "Proceed",
     "homeBottomBarHome": "Home",
     "homeBottomBarTracks": "Tracks",
     "tracksAppBarTitle": "Tracks",
@@ -165,6 +166,7 @@
     "settingsDeleteAllDataError": "Failed to delete all data. Please try again.",
     "accountManagement": "Account Management",
     "deleteAllHint": "This will delete all your tracks from the app.",
-    "generalConfirmation": "Confirmation"
+    "generalConfirmation": "Confirmation",
+    "privacyPolicyAccept": "I accept the Privacy Policy"
 
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -167,7 +167,6 @@
     "accountManagement": "Account Management",
     "deleteAllHint": "This will delete all your tracks from the app.",
     "generalConfirmation": "Confirmation",
-    "privacyPolicyAccept": "I accept the Privacy Policy",
-    "scrollToAcceptHint": "Please review and accept the Privacy Policy to continue using the app."
+    "privacyPolicyAccept": "I have read and accept the Privacy Policy."
 
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -45,6 +45,7 @@
     "generalLogin": "Entrar",
     "generalLogout": "Sair",
     "generalRegister": "Registrar-se",
+    "generalProceed": "Prosseguir",
     "homeBottomBarHome": "Início",
     "homeBottomBarTracks": "Trajetos",
     "tracksAppBarTitle": "Trajetos",
@@ -165,6 +166,7 @@
     "settingsDeleteAllDataError": "Falha ao excluir todos os dados. Por favor, tente novamente.",
     "accountManagement": "Gerenciamento de Conta",
     "deleteAllHint": "Isso excluirá todas as suas faixas do aplicativo.",
-    "generalConfirmation": "Confirmação"
+    "generalConfirmation": "Confirmação",
+    "privacyPolicyAccept": "Eu aceito a política de privacidade"
 
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -167,7 +167,6 @@
     "accountManagement": "Gerenciamento de Conta",
     "deleteAllHint": "Isso excluirá todas as suas faixas do aplicativo.",
     "generalConfirmation": "Confirmação",
-    "privacyPolicyAccept": "Eu aceito a política de privacidade",
-    "scrollToAcceptHint": "Por favor, leia e aceite a política de privacidade para continuar usando o aplicativo."
+    "privacyPolicyAccept": "Eu li e aceito a política de privacidade."
 
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -167,6 +167,7 @@
     "accountManagement": "Gerenciamento de Conta",
     "deleteAllHint": "Isso excluirá todas as suas faixas do aplicativo.",
     "generalConfirmation": "Confirmação",
-    "privacyPolicyAccept": "Eu aceito a política de privacidade"
+    "privacyPolicyAccept": "Eu aceito a política de privacidade",
+    "scrollToAcceptHint": "Por favor, leia e aceite a política de privacidade para continuar usando o aplicativo."
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,7 +20,7 @@ import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/services/isar_service/isar_provider.dart';
 import 'package:sensebox_bike/theme.dart';
-import 'package:sensebox_bike/ui/screens/app_home.dart';
+import 'package:sensebox_bike/ui/screens/initial_screen.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
@@ -119,7 +119,7 @@ class SenseBoxBikeApp extends StatelessWidget {
         supportedLocales: AppLocalizations.supportedLocales,
         theme: lightTheme,
         darkTheme: darkTheme,
-        home: const AppHome(),
+        home: const InitialScreen(),
       ),
     );
   }

--- a/lib/ui/screens/initial_screen.dart
+++ b/lib/ui/screens/initial_screen.dart
@@ -3,6 +3,7 @@ import 'package:sensebox_bike/constants.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sensebox_bike/ui/screens/app_home.dart';
 import 'package:sensebox_bike/ui/screens/privacy_policy_screen.dart';
+import 'package:sensebox_bike/feature_flags.dart';
 
 class InitialScreen extends StatefulWidget {
   const InitialScreen({super.key});
@@ -18,24 +19,27 @@ class _InitialScreenState extends State<InitialScreen> {
     _checkPrivacyPolicyAcceptance();
   }
 
-  Future<void> _checkPrivacyPolicyAcceptance() async {
+Future<void> _checkPrivacyPolicyAcceptance() async {
     final prefs = await SharedPreferences.getInstance();
-    final acceptedAt = prefs.getString(SharedPreferencesKeys.privacyPolicyAcceptedAt);
+    final acceptedAt =
+        prefs.getString(SharedPreferencesKeys.privacyPolicyAcceptedAt);
 
     if (!context.mounted) return;
 
-    if (acceptedAt != null) {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (context) => const AppHome()),
-      );
-    } else {
-      Navigator.pushReplacement(
-        context,
-        MaterialPageRoute(builder: (context) => const PrivacyPolicyScreen()),
-      );
+    final Widget nextScreen = _getNextScreen(acceptedAt);
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(builder: (context) => nextScreen),
+    );
+}
+
+Widget _getNextScreen(String? acceptedAt) {
+    if (!FeatureFlags.showPrivacyPolicyScreen) {
+      return const AppHome();
     }
-  }
+
+    return acceptedAt != null ? const AppHome() : const PrivacyPolicyScreen();
+}
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/screens/initial_screen.dart
+++ b/lib/ui/screens/initial_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:sensebox_bike/constants.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sensebox_bike/ui/screens/app_home.dart';
+import 'package:sensebox_bike/ui/screens/privacy_policy_screen.dart';
+
+class InitialScreen extends StatefulWidget {
+  const InitialScreen({super.key});
+
+  @override
+  _InitialScreenState createState() => _InitialScreenState();
+}
+
+class _InitialScreenState extends State<InitialScreen> {
+  @override
+  void initState() {
+    super.initState();
+    _checkPrivacyPolicyAcceptance();
+  }
+
+  Future<void> _checkPrivacyPolicyAcceptance() async {
+    final prefs = await SharedPreferences.getInstance();
+    final acceptedAt = prefs.getString(SharedPreferencesKeys.privacyPolicyAcceptedAt);
+
+    if (!context.mounted) return;
+
+    if (acceptedAt != null) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const AppHome()),
+      );
+    } else {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const PrivacyPolicyScreen()),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/privacy_policy_screen.dart
+++ b/lib/ui/screens/privacy_policy_screen.dart
@@ -4,6 +4,7 @@ import 'package:sensebox_bike/constants.dart';
 import 'package:sensebox_bike/theme.dart';
 import 'package:sensebox_bike/ui/screens/app_home.dart';
 import 'package:sensebox_bike/ui/widgets/common/checkbox_with_text.dart';
+import 'package:sensebox_bike/ui/widgets/common/custom_spacer.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -101,7 +102,7 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
                 Center(child: CircularProgressIndicator())
               else
                 Expanded(child: WebViewWidget(controller: _controller)),
-              const SizedBox(height: spacing),
+              const CustomSpacer(),
               Row(
                 children: [
                   Icon(Icons.info_outline, color: colorScheme.primaryFixedDim),
@@ -117,7 +118,7 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
                   ),
                 ],
               ),
-              const SizedBox(height: spacing),
+              const CustomSpacer(),
               CheckboxWithText(
                 value: _isCheckboxChecked,
                 onChanged: (value) {
@@ -126,9 +127,8 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
                   });
                 },
                 text: localizations.privacyPolicyAccept,
-                offset: const Offset(-12, 0), // Apply the desired offset
               ),
-              const SizedBox(height: spacing),
+              const CustomSpacer(),
               Center(
                 child: FilledButton(
                   onPressed: (_isCheckboxChecked && _hasScrolledToBottom)
@@ -143,7 +143,7 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
                       : null,
                   child: Text(localizations.generalProceed),
                 ),
-),
+              ),
         ],
       ),
     ));

--- a/lib/ui/screens/privacy_policy_screen.dart
+++ b/lib/ui/screens/privacy_policy_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // For translations
 import 'package:sensebox_bike/constants.dart';
+import 'package:sensebox_bike/theme.dart';
 import 'package:sensebox_bike/ui/screens/app_home.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -28,7 +29,10 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
   @override
   void initState() {
     super.initState();
+    _initializeWebView();
+  }
 
+  void _initializeWebView() {
     _controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..addJavaScriptChannel(
@@ -44,32 +48,7 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
       ..setNavigationDelegate(
         NavigationDelegate(
           onPageFinished: (String url) async {
-            // Inject JavaScript to extract the desired HTML content
-            await _controller.runJavaScript('''
-              (function() {
-                // Extract content between the specified comments
-                const containerStart = document.body.innerHTML.indexOf('<!-- <div class="container-fluid"> -->');
-                const containerEnd = document.body.innerHTML.indexOf('<!-- </div> -->', containerStart);
-                if (containerStart !== -1 && containerEnd !== -1) {
-                  const extractedContent = document.body.innerHTML.substring(containerStart, containerEnd);
-                  document.body.innerHTML = extractedContent; 
-                }
-
-                // Add a scroll event listener to detect when scrolled to the bottom
-                const sendMessageToFlutter = function(message) {
-                  ScrollHandler.postMessage(message);
-                };
-
-                window.onscroll = function() {
-                  const scrollPosition = window.scrollY || document.documentElement.scrollTop;
-                  const maxScroll = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-                  if (scrollPosition >= maxScroll - 10) {
-                    sendMessageToFlutter('scrolledToBottom');
-                  }
-                };
-              })();
-            ''');
-            // Hide the loader after the content is processed
+            await _injectJavaScript();
             setState(() {
               _isLoading = false;
             });
@@ -79,54 +58,82 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
       ..loadRequest(Uri.parse(senseBoxBikePrivacyPolicyUrl));
   }
 
+  Future<void> _injectJavaScript() async {
+    await _controller.runJavaScript('''
+      (function() {
+        // On the website page content is placed inside the following containers
+        const containerStart = document.body.innerHTML.indexOf('<!-- <div class="container-fluid"> -->');
+        const containerEnd = document.body.innerHTML.indexOf('<!-- </div> -->', containerStart);
+        if (containerStart !== -1 && containerEnd !== -1) {
+          const extractedContent = document.body.innerHTML.substring(containerStart, containerEnd);
+          document.body.innerHTML = extractedContent; 
+        }
+
+        const sendMessageToFlutter = function(message) {
+          ScrollHandler.postMessage(message);
+        };
+
+        window.onscroll = function() {
+          const scrollPosition = window.scrollY || document.documentElement.scrollTop;
+          const maxScroll = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+          if (scrollPosition >= maxScroll - 10) {
+            sendMessageToFlutter('scrolledToBottom');
+          }
+        };
+      })();
+    ''');
+  }
+
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text(localizations.settingsPrivacyPolicy),
-      ),
+        appBar: AppBar(title: Text(localizations.settingsPrivacyPolicy)),
       body: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 12.0),
-      child: Column(
-        children: [
-          if (_isLoading) Center(child: CircularProgressIndicator())
-          else Expanded(child: WebViewWidget(controller: _controller)),
-          Padding(
-            padding: const EdgeInsets.all(12.0),
-            child: Column(
-              children: [
-                Row(
+          padding: const EdgeInsets.symmetric(
+              vertical: spacing * 2, horizontal: spacing),
+          child: Column(
+            children: [
+              if (_isLoading)
+                Center(child: CircularProgressIndicator())
+              else
+                Expanded(child: WebViewWidget(controller: _controller)),
+              Padding(
+                padding: const EdgeInsets.all(spacing),
+                child: Column(
                   children: [
-                    Checkbox(
-                      value: _isCheckboxChecked,
-                      onChanged: (value) {
-                        setState(() {
-                          _isCheckboxChecked = value ?? false;
-                        });
-                      },
+                    Row(
+                      children: [
+                        Checkbox(
+                          value: _isCheckboxChecked,
+                          onChanged: (value) {
+                            setState(() {
+                              _isCheckboxChecked = value ?? false;
+                            });
+                          },
+                        ),
+                        Expanded(
+                          child: Text(localizations.privacyPolicyAccept),
+                        ),
+                      ],
                     ),
-                    Expanded(
-                      child: Text(localizations.privacyPolicyAccept),
+                    const SizedBox(height: spacing),
+                    FilledButton(
+                      onPressed: (_isCheckboxChecked && _hasScrolledToBottom)
+                          ? () async {
+                              await _saveAcceptanceDate();
+                              Navigator.pushReplacement(
+                                context,
+                                MaterialPageRoute(
+                                    builder: (context) => const AppHome()),
+                              );
+                            }
+                          : null,
+                      child: Text(localizations.generalProceed),
                     ),
                   ],
                 ),
-                const SizedBox(height: 12),
-                FilledButton(
-                  onPressed: (_isCheckboxChecked && _hasScrolledToBottom)
-                      ? () async {
-                          await _saveAcceptanceDate(); 
-                          Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(builder: (context) => const AppHome()),
-                          );
-                        }
-                      : null,
-                  child: Text(localizations.generalProceed),
-                ),
-              ],
-            ),
           ),
         ],
       ),

--- a/lib/ui/screens/privacy_policy_screen.dart
+++ b/lib/ui/screens/privacy_policy_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // For translations
+import 'package:sensebox_bike/constants.dart';
+import 'package:sensebox_bike/ui/screens/app_home.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+class PrivacyPolicyScreen extends StatefulWidget {
+  const PrivacyPolicyScreen({Key? key}) : super(key: key);
+
+  @override
+  _PrivacyPolicyScreenState createState() => _PrivacyPolicyScreenState();
+}
+
+class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
+  bool _isCheckboxChecked = false;
+  bool _hasScrolledToBottom = false;
+  bool _isLoading = true;
+  late final WebViewController _controller;
+
+  Future<void> _saveAcceptanceDate() async {
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now().toIso8601String();
+
+    await prefs.setString(SharedPreferencesKeys.privacyPolicyAcceptedAt, now);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..addJavaScriptChannel(
+        'ScrollHandler',
+        onMessageReceived: (message) {
+          if (message.message == 'scrolledToBottom') {
+            setState(() {
+              _hasScrolledToBottom = true;
+            });
+          }
+        },
+      )
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (String url) async {
+            // Inject JavaScript to extract the desired HTML content
+            await _controller.runJavaScript('''
+              (function() {
+                // Extract content between the specified comments
+                const containerStart = document.body.innerHTML.indexOf('<!-- <div class="container-fluid"> -->');
+                const containerEnd = document.body.innerHTML.indexOf('<!-- </div> -->', containerStart);
+                if (containerStart !== -1 && containerEnd !== -1) {
+                  const extractedContent = document.body.innerHTML.substring(containerStart, containerEnd);
+                  document.body.innerHTML = extractedContent; 
+                }
+
+                // Add a scroll event listener to detect when scrolled to the bottom
+                const sendMessageToFlutter = function(message) {
+                  ScrollHandler.postMessage(message);
+                };
+
+                window.onscroll = function() {
+                  const scrollPosition = window.scrollY || document.documentElement.scrollTop;
+                  const maxScroll = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+                  if (scrollPosition >= maxScroll - 10) {
+                    sendMessageToFlutter('scrolledToBottom');
+                  }
+                };
+              })();
+            ''');
+            // Hide the loader after the content is processed
+            setState(() {
+              _isLoading = false;
+            });
+          },
+        ),
+      )
+      ..loadRequest(Uri.parse(senseBoxBikePrivacyPolicyUrl));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(localizations.settingsPrivacyPolicy),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 12.0),
+      child: Column(
+        children: [
+          if (_isLoading) Center(child: CircularProgressIndicator())
+          else Expanded(child: WebViewWidget(controller: _controller)),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Checkbox(
+                      value: _isCheckboxChecked,
+                      onChanged: (value) {
+                        setState(() {
+                          _isCheckboxChecked = value ?? false;
+                        });
+                      },
+                    ),
+                    Expanded(
+                      child: Text(localizations.privacyPolicyAccept),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                FilledButton(
+                  onPressed: (_isCheckboxChecked && _hasScrolledToBottom)
+                      ? () async {
+                          await _saveAcceptanceDate(); 
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => const AppHome()),
+                          );
+                        }
+                      : null,
+                  child: Text(localizations.generalProceed),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ));
+  }
+}

--- a/lib/ui/screens/privacy_policy_screen.dart
+++ b/lib/ui/screens/privacy_policy_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // For translation
 import 'package:sensebox_bike/constants.dart';
 import 'package:sensebox_bike/theme.dart';
 import 'package:sensebox_bike/ui/screens/app_home.dart';
+import 'package:sensebox_bike/ui/widgets/common/checkbox_with_text.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -104,7 +105,7 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
               Row(
                 children: [
                   Icon(Icons.info_outline, color: colorScheme.primaryFixedDim),
-                  const SizedBox(width: spacing / 2),
+                  const SizedBox(width: spacing),
                   Expanded(
                     child: Text(
                       localizations.scrollToAcceptHint,
@@ -117,18 +118,15 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
                 ],
               ),
               const SizedBox(height: spacing),
-              Row(
-                children: [
-                  Checkbox(
-                    value: _isCheckboxChecked,
-                    onChanged: (value) {
-                      setState(() {
-                        _isCheckboxChecked = value ?? false;
-                      });
-                    },
-                  ),
-                  Text(localizations.privacyPolicyAccept),
-                ],
+              CheckboxWithText(
+                value: _isCheckboxChecked,
+                onChanged: (value) {
+                  setState(() {
+                    _isCheckboxChecked = value ?? false;
+                  });
+                },
+                text: localizations.privacyPolicyAccept,
+                offset: const Offset(-12, 0), // Apply the desired offset
               ),
               const SizedBox(height: spacing),
               Center(

--- a/lib/ui/screens/privacy_policy_screen.dart
+++ b/lib/ui/screens/privacy_policy_screen.dart
@@ -87,54 +87,65 @@ class _PrivacyPolicyScreenState extends State<PrivacyPolicyScreen> {
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
         appBar: AppBar(title: Text(localizations.settingsPrivacyPolicy)),
       body: Padding(
-          padding: const EdgeInsets.symmetric(
-              vertical: spacing * 2, horizontal: spacing),
+          padding: const EdgeInsets.all(spacing * 1.5),
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               if (_isLoading)
                 Center(child: CircularProgressIndicator())
               else
                 Expanded(child: WebViewWidget(controller: _controller)),
-              Padding(
-                padding: const EdgeInsets.all(spacing),
-                child: Column(
-                  children: [
-                    Row(
-                      children: [
-                        Checkbox(
-                          value: _isCheckboxChecked,
-                          onChanged: (value) {
-                            setState(() {
-                              _isCheckboxChecked = value ?? false;
-                            });
-                          },
-                        ),
-                        Expanded(
-                          child: Text(localizations.privacyPolicyAccept),
-                        ),
-                      ],
+              const SizedBox(height: spacing),
+              Row(
+                children: [
+                  Icon(Icons.info_outline, color: colorScheme.primaryFixedDim),
+                  const SizedBox(width: spacing / 2),
+                  Expanded(
+                    child: Text(
+                      localizations.scrollToAcceptHint,
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodySmall
+                          ?.copyWith(color: colorScheme.primaryFixedDim),
                     ),
-                    const SizedBox(height: spacing),
-                    FilledButton(
-                      onPressed: (_isCheckboxChecked && _hasScrolledToBottom)
-                          ? () async {
-                              await _saveAcceptanceDate();
-                              Navigator.pushReplacement(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => const AppHome()),
-                              );
-                            }
-                          : null,
-                      child: Text(localizations.generalProceed),
-                    ),
-                  ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: spacing),
+              Row(
+                children: [
+                  Checkbox(
+                    value: _isCheckboxChecked,
+                    onChanged: (value) {
+                      setState(() {
+                        _isCheckboxChecked = value ?? false;
+                      });
+                    },
+                  ),
+                  Text(localizations.privacyPolicyAccept),
+                ],
+              ),
+              const SizedBox(height: spacing),
+              Center(
+                child: FilledButton(
+                  onPressed: (_isCheckboxChecked && _hasScrolledToBottom)
+                      ? () async {
+                          await _saveAcceptanceDate();
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => const AppHome()),
+                          );
+                        }
+                      : null,
+                  child: Text(localizations.generalProceed),
                 ),
-          ),
+),
         ],
       ),
     ));

--- a/lib/ui/widgets/common/checkbox_with_text.dart
+++ b/lib/ui/widgets/common/checkbox_with_text.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class CheckboxWithText extends StatelessWidget {
+  final bool value;
+  final ValueChanged<bool?> onChanged;
+  final String text;
+  final Offset offset; 
+
+  const CheckboxWithText({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    required this.text,
+    this.offset = const Offset(0, 0),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Transform.translate(
+      offset: offset, 
+      child: Row(
+        children: [
+          Checkbox(value: value,onChanged: onChanged),
+          Text(text),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/common/checkbox_with_text.dart
+++ b/lib/ui/widgets/common/checkbox_with_text.dart
@@ -11,7 +11,7 @@ class CheckboxWithText extends StatelessWidget {
     required this.value,
     required this.onChanged,
     required this.text,
-    this.offset = const Offset(0, 0),
+    this.offset = const Offset(-12, 0),
   });
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1463,6 +1463,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: c3e4fe614b1c814950ad07186007eff2f2e5dd2935eba7b9a9a1af8e5885f1ba
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: f6e6afef6e234801da77170f7a1847ded8450778caf2fe13979d140484be3678
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "7cb32b21825bd65569665c32bb00a34ded5779786d6201f5350979d2d529940d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: a3d461fe3467014e05f3ac4962e5fdde2a4bf44c561cb53e9ae5c586600fdbc3
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.22.0"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
     sdk: flutter
   mocktail: ^1.0.4
   simplify: ^1.1.0
+  webview_flutter: ^4.13.0
 
 dev_dependencies:
   flutter_test:

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,5 +1,7 @@
-import 'package:flutter/foundation.dart';
+
+import 'package:flutter/material.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
 import 'package:sensebox_bike/blocs/track_bloc.dart';
 import 'package:sensebox_bike/models/sensor_data.dart';
@@ -43,3 +45,98 @@ class MockOpenSenseMapBloc extends OpenSenseMapBloc {
 
 class MockSensor extends Mock implements Sensor {}
 class FakeSensorData extends Fake implements SensorData {}
+
+// Mocks for webview_flutter
+
+class FakeWebViewPlatform extends WebViewPlatform {
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+    PlatformWebViewControllerCreationParams params,
+  ) {
+    return FakeWebViewController(params);
+  }
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+    PlatformWebViewWidgetCreationParams params,
+  ) {
+    return FakeWebViewWidget(params);
+  }
+
+  @override
+  PlatformWebViewCookieManager createPlatformCookieManager(
+    PlatformWebViewCookieManagerCreationParams params,
+  ) {
+    return FakeCookieManager(params);
+  }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+    PlatformNavigationDelegateCreationParams params,
+  ) {
+    return FakeNavigationDelegate(params);
+  }
+}
+
+class FakeWebViewController extends PlatformWebViewController {
+  FakeWebViewController(super.params) : super.implementation();
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) async {}
+
+  @override
+  Future<void> setBackgroundColor(Color color) async {}
+
+  @override
+  Future<void> setPlatformNavigationDelegate(
+    PlatformNavigationDelegate handler,
+  ) async {}
+
+  @override
+  Future<void> addJavaScriptChannel(
+      JavaScriptChannelParams javaScriptChannelParams) async {}
+
+  @override
+  Future<void> loadRequest(LoadRequestParams params) async {}
+
+  @override
+  Future<String?> currentUrl() async {
+    return 'https://www.google.com';
+  }
+}
+
+class FakeCookieManager extends PlatformWebViewCookieManager {
+  FakeCookieManager(super.params) : super.implementation();
+}
+
+class FakeWebViewWidget extends PlatformWebViewWidget {
+  FakeWebViewWidget(super.params) : super.implementation();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Fake WebView Content', key: Key('FakeWebViewWidget'));
+  }
+}
+
+class FakeNavigationDelegate extends PlatformNavigationDelegate {
+  FakeNavigationDelegate(super.params) : super.implementation();
+
+  @override
+  Future<void> setOnNavigationRequest(
+    NavigationRequestCallback onNavigationRequest,
+  ) async {}
+
+  @override
+  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {}
+
+  @override
+  Future<void> setOnPageStarted(PageEventCallback onPageStarted) async {}
+
+  @override
+  Future<void> setOnProgress(ProgressCallback onProgress) async {}
+
+  @override
+  Future<void> setOnWebResourceError(
+    WebResourceErrorCallback onWebResourceError,
+  ) async {}
+}

--- a/test/ui/screens/privacy_policy_screen_test.dart
+++ b/test/ui/screens/privacy_policy_screen_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sensebox_bike/constants.dart';
+import 'package:sensebox_bike/ui/screens/privacy_policy_screen.dart';
+import 'package:http/http.dart' as http;
+import 'package:webview_flutter/webview_flutter.dart';
+import '../../test_helpers.dart';
+import '../../mocks.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  late MockHttpClient mockHttpClient;
+  const htmlContent = '''
+    <html>
+      <body>
+        <div class="container-fluid">Privacy Policy Content</div>
+      </body>
+    </html>
+  ''';
+
+  setUpAll(() {
+    WebViewPlatform.instance = FakeWebViewPlatform();
+  });
+
+  setUp(() {
+    initializeTestDependencies();
+    mockHttpClient = MockHttpClient();
+  });
+
+  group('PrivacyPolicyScreen Tests', () {
+    testWidgets('displays loading indicator while fetching privacy policy',
+        (WidgetTester tester) async {
+      when(() => mockHttpClient.get(Uri.parse(senseBoxBikePrivacyPolicyUrl)))
+          .thenAnswer((_) async => http.Response(htmlContent, 200));
+
+      await tester.pumpWidget(createLocalizedTestApp(
+        child: const PrivacyPolicyScreen(),
+        locale: const Locale('en'),
+      ));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      // Verify the title of the page
+      expect(find.text('Privacy Policy'), findsOneWidget);
+
+      // Verify the hint text is displayed
+      expect(find.text('Please review and accept the Privacy Policy to continue using the app.'), findsOneWidget);
+
+      // Verify the checkbox is displayed and unchecked by default
+      final checkboxFinder = find.byType(Checkbox);
+      expect(checkboxFinder, findsOneWidget);
+      expect(tester.widget<Checkbox>(checkboxFinder).value, isFalse);
+
+      // Verify the button with text "Proceed" is displayed and disabled
+      final proceedButtonFinder = find.widgetWithText(FilledButton, 'Proceed');
+      expect(proceedButtonFinder, findsOneWidget);
+      expect(tester.widget<FilledButton>(proceedButtonFinder).enabled, isFalse);
+    });
+
+    // TBD: write more tests for the PrivacyPolicyScreen
+    // with inspiration from https://github.com/flutter/flutter/issues/117422
+  });
+}

--- a/test/ui/screens/privacy_policy_screen_test.dart
+++ b/test/ui/screens/privacy_policy_screen_test.dart
@@ -44,9 +44,6 @@ void main() {
       // Verify the title of the page
       expect(find.text('Privacy Policy'), findsOneWidget);
 
-      // Verify the hint text is displayed
-      expect(find.text('Please review and accept the Privacy Policy to continue using the app.'), findsOneWidget);
-
       // Verify the checkbox is displayed and unchecked by default
       final checkboxFinder = find.byType(Checkbox);
       expect(checkboxFinder, findsOneWidget);


### PR DESCRIPTION
Closes #77

### Detailed Changes

*   Adds screen on the app start to accept privacy policy (if user hasn't accepted the policy before)
*   Pulls text of the privacypolicy from the website

### Testing
On the next app start you should see screen with privacy policy consent.
Also you can install DevTools extension to see your consent in the shared prefs (https://pub.dev/packages/devtools_extensions).

! I wasn't able to add more meaningful tests due to complications with webview_flutter mocking

### Checklist before requesting a review

[x] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation

### Additional Information

- Tests inspired by this issue https://github.com/flutter/flutter/issues/117422
