### PR TITLE
Hotfix: exception after leaving login page prematurely

### DIFF
--- a/lib/ui/widgets/opensensemap/login.dart
+++ b/lib/ui/widgets/opensensemap/login.dart
@@ -82,13 +82,17 @@ class _LoginFormState extends State<LoginForm> {
                                 ErrorService.handleError(LoginError(e), stack,
                                     sendToSentry: false);
                               } finally {
-                                setState(() {
+                                if (mounted) {
+                                  setState(() {
                                   isLoading = false; // Stop loading
                                 });
+                                }
                               }
 
-                              // Navigate only if login was successful
-                              if (isLoginSuccessful && context.mounted) {
+                              // Navigate only if login was successful and user is still on the page
+                              if (isLoginSuccessful &&
+                                  context.mounted &&
+                                  mounted) {
                                 Navigator.pushReplacement(
                                   context,
                                   MaterialPageRoute(

--- a/lib/ui/widgets/opensensemap/register.dart
+++ b/lib/ui/widgets/opensensemap/register.dart
@@ -189,12 +189,16 @@ class _RegisterFormState extends State<RegisterForm> {
                               ErrorService.handleError(
                                   RegistrationError(e), stack);
                             } finally {
-                              setState(() {
-                                isLoading = false; // Stop loading
-                              });
+                              if (mounted) {
+                                setState(() {
+                                  isLoading = false; // Stop loading
+                                });
+                              }
                             }
 
-                            if (context.mounted && isRegistrationSuccessful) {
+                            if (context.mounted &&
+                                isRegistrationSuccessful &&
+                                mounted) {
                               // Navigate to the home screen after successful login
                               Navigator.pushReplacement(
                                 context,


### PR DESCRIPTION
Closes #

If I leave login screen before login is complete app throws an error. For my partner's phone app closes and i cannot restart it.

### Detailed Changes
Added check to see, if widget is still mounted before navigating off and resetting widget state.

### Testing
- start login process
- navigate to home page
=> eventually you should see dark green element with info about box

### Checklist before requesting a review

[ ] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation