### PR TITLE
Fix: authentication after key refresh & data storage when no internet connection

### DIFF
--- a/lib/blocs/geolocation_bloc.dart
+++ b/lib/blocs/geolocation_bloc.dart
@@ -36,7 +36,6 @@ class GeolocationBloc with ChangeNotifier {
         if (status.isGranted) {
           locationSettings = AndroidSettings(
               accuracy: LocationAccuracy.best,
-              timeLimit: const Duration(minutes: 1),
               foregroundNotificationConfig: const ForegroundNotificationConfig(
                   notificationText:
                       "senseBox:bike will record your location in the background",
@@ -52,7 +51,6 @@ class GeolocationBloc with ChangeNotifier {
           defaultTargetPlatform == TargetPlatform.macOS) {
         locationSettings = AppleSettings(
           accuracy: LocationAccuracy.best,
-          timeLimit: const Duration(minutes: 1),
         );
       }
 

--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -85,7 +85,8 @@ class RecordingBloc with ChangeNotifier {
       _directUploadService = DirectUploadService(
           openSenseMapService: OpenSenseMapService(),
           settingsBloc: settingsBloc,
-          senseBox: _selectedSenseBox!);
+          senseBox: _selectedSenseBox!,
+          openSenseMapBloc: openSenseMapBloc);
 
       _onRecordingStart?.call();
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -170,6 +170,7 @@
     "errorRegistrationFailed": "Registrierung fehlgeschlagen. Bitte überprüfen Sie Ihre Anmeldedaten.",
     "errorBleConnectionFailed": "Die Verbindung zur senseBox wurde unterbrochen. Bitte stellen Sie sicher, dass Bluetooth aktiviert ist und die senseBox eingeschaltet ist.",
     "errorUploadFailed": "Daten-Upload fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.",
+    "errorPermanentAuthentication": "Authentifizierung dauerhaft fehlgeschlagen. Bitte melden Sie sich erneut an, um den Upload fortzusetzen.",
     "selectCsvFormat": "CSV-Format auswählen",
     "regularCsv": "Standard CSV",
     "openSenseMapCsv": "openSenseMap CSV",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -170,6 +170,7 @@
     "errorRegistrationFailed": "Registration failed. Please check your credentials.",
     "errorBleConnectionFailed": "Connect to the senseBox was lost. Please make sure Bluetooth is enabled and the senseBox is powered on.",
     "errorUploadFailed": "Data upload failed. Please check your internet connection and try again.",
+    "errorPermanentAuthentication": "Authentication failed permanently. Please log in again to continue uploading data.",
     "selectCsvFormat": "Select CSV format",
     "regularCsv": "Standard CSV",
     "openSenseMapCsv": "openSenseMap CSV",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -871,6 +871,12 @@ abstract class AppLocalizations {
   /// **'Data upload failed. Please check your internet connection and try again.'**
   String get errorUploadFailed;
 
+  /// No description provided for @errorPermanentAuthentication.
+  ///
+  /// In en, this message translates to:
+  /// **'Authentication failed permanently. Please log in again to continue uploading data.'**
+  String get errorPermanentAuthentication;
+
   /// No description provided for @selectCsvFormat.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -415,6 +415,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get errorUploadFailed => 'Daten-Upload fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut.';
 
   @override
+  String get errorPermanentAuthentication => 'Authentifizierung dauerhaft fehlgeschlagen. Bitte melden Sie sich erneut an, um den Upload fortzusetzen.';
+
+  @override
   String get selectCsvFormat => 'CSV-Format auswählen';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -415,6 +415,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get errorUploadFailed => 'Data upload failed. Please check your internet connection and try again.';
 
   @override
+  String get errorPermanentAuthentication => 'Authentication failed permanently. Please log in again to continue uploading data.';
+
+  @override
   String get selectCsvFormat => 'Select CSV format';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -415,6 +415,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get errorUploadFailed => 'Falha no upload de dados. Por favor, verifique sua conexão com a internet e tente novamente.';
 
   @override
+  String get errorPermanentAuthentication => 'Falha permanente na autenticação. Por favor, faça login novamente para continuar fazendo upload.';
+
+  @override
   String get selectCsvFormat => 'Selecionar formato CSV';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -170,6 +170,7 @@
     "errorRegistrationFailed": "Falha no registro. Por favor, verifique suas credenciais.",
     "errorBleConnectionFailed": "A conexão com a senseBox foi perdida. Por favor, certifique-se de que o Bluetooth está ativado e a senseBox está ligada.",
     "errorUploadFailed": "Falha no upload de dados. Por favor, verifique sua conexão com a internet e tente novamente.",
+    "errorPermanentAuthentication": "Falha permanente na autenticação. Por favor, faça login novamente para continuar fazendo upload.",
     "selectCsvFormat": "Selecionar formato CSV",
     "regularCsv": "CSV padrão",
     "openSenseMapCsv": "CSV openSenseMap",

--- a/lib/services/custom_exceptions.dart
+++ b/lib/services/custom_exceptions.dart
@@ -51,3 +51,14 @@ class UploadFailureError implements Exception {
   String toString() =>
       'Data upload failed. Please check your internet connection and try again.';
 }
+
+class PermanentAuthenticationError implements Exception {
+  final String? details;
+
+  PermanentAuthenticationError([this.details]);
+
+  @override
+  String toString() => details != null
+      ? 'Authentication failed permanently: $details'
+      : 'Authentication failed permanently. Please log in again to continue uploading data.';
+}

--- a/lib/services/custom_exceptions.dart
+++ b/lib/services/custom_exceptions.dart
@@ -59,6 +59,6 @@ class PermanentAuthenticationError implements Exception {
 
   @override
   String toString() => details != null
-      ? 'Authentication failed permanently: $details'
-      : 'Authentication failed permanently. Please log in again to continue uploading data.';
+      ? 'Authentication failed permanently: $details. Data upload is stopped but all data is stored locally.'
+      : 'Authentication failed permanently. Data upload is stopped but all data is stored locally. Please log in again to continue uploading data.';
 }

--- a/lib/services/direct_upload_service.dart
+++ b/lib/services/direct_upload_service.dart
@@ -218,7 +218,7 @@ class DirectUploadService {
 
     _directUploadBuffer.add(uploadDataWithGps);
 
-    if (_directUploadBuffer.length >= 6) {
+    if (_directUploadBuffer.length >= 3) {
       _uploadDirectBuffer().catchError((e) {
         ErrorService.handleError(
             'Direct upload failed at ${DateTime.now()}: ${e.toString()}',

--- a/lib/services/error_service.dart
+++ b/lib/services/error_service.dart
@@ -28,7 +28,8 @@ class ErrorService {
           error is ScanPermissionDenied ||
           error is NoSenseBoxSelected ||
           error is ExportDirectoryAccessError ||
-          error is UploadFailureError) {
+          error is UploadFailureError ||
+          error is PermanentAuthenticationError) {
         showUserFeedback(error);
       } else {
         logToConsole(error, stack);
@@ -72,6 +73,9 @@ class ErrorService {
     } else if (error is UploadFailureError) {
       return localizations?.errorUploadFailed ??
           'Data upload failed. Please check your internet connection and try again.';
+    } else if (error is PermanentAuthenticationError) {
+      return localizations?.errorPermanentAuthentication ??
+          'Authentication failed permanently. Please log in again to continue uploading data.';
     } else if (error is LoginError) {
       return '${localizations?.errorLoginFailed} ${error.toString()}';
     } else if (error is RegistrationError) {

--- a/lib/services/opensensemap_service.dart
+++ b/lib/services/opensensemap_service.dart
@@ -453,14 +453,15 @@ class OpenSenseMapService {
       String senseBoxId, Map<String, dynamic> sensorData) async {
     List<dynamic> data = sensorData.values.toList();
 
-    // Check if data exceeds 2450 items and trim if needed to stay under the API limit
-    if (data.length > 2450) {
-      final int itemsToRemove = data.length - 2450;
+    // Check if data exceeds 2500 items and trim if needed to stay under the API limit
+    const maxItems = 2450;
+    if (data.length > maxItems) {
+      final int itemsToRemove = data.length - maxItems;
       data = data.skip(itemsToRemove).toList();
 
       // Log the trimming event
       ErrorService.handleError(
-        'Data trimmed before upload: Removed $itemsToRemove oldest items to stay under 2450 limit (original: ${sensorData.values.length}, final: ${data.length})',
+        'Data trimmed before upload: Removed $itemsToRemove oldest items to stay under $maxItems limit (original: ${sensorData.values.length}, final: ${data.length})',
         StackTrace.current,
         sendToSentry: true,
       );

--- a/lib/services/opensensemap_service.dart
+++ b/lib/services/opensensemap_service.dart
@@ -283,7 +283,7 @@ class OpenSenseMapService {
       }
       final expirationTime = DateTime.fromMillisecondsSinceEpoch(exp * 1000);
       final now = DateTime.now();
-      // Code to test if token is expired
+      // Temporary: Code to test if token is expired
       // final fakeExpiredTime = now.subtract(Duration(hours: 1));
       // return expirationTime.isAfter(fakeExpiredTime);
       return expirationTime.isAfter(now);

--- a/lib/services/opensensemap_service.dart
+++ b/lib/services/opensensemap_service.dart
@@ -453,6 +453,19 @@ class OpenSenseMapService {
       String senseBoxId, Map<String, dynamic> sensorData) async {
     List<dynamic> data = sensorData.values.toList();
 
+    // Check if data exceeds 2450 items and trim if needed to stay under the API limit
+    if (data.length > 2450) {
+      final int itemsToRemove = data.length - 2450;
+      data = data.skip(itemsToRemove).toList();
+
+      // Log the trimming event
+      ErrorService.handleError(
+        'Data trimmed before upload: Removed $itemsToRemove oldest items to stay under 2450 limit (original: ${sensorData.values.length}, final: ${data.length})',
+        StackTrace.current,
+        sendToSentry: true,
+      );
+    }
+
     // Check if currently rate limited
     if (_isRateLimited) {
       final remaining = _rateLimitUntil?.difference(DateTime.now());

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -116,110 +116,117 @@ class HomeScreen extends StatelessWidget {
 class _SenseBoxSelectionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final OpenSenseMapBloc osemBloc = Provider.of<OpenSenseMapBloc>(context);
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
+    return Consumer<OpenSenseMapBloc>(
+      builder: (context, osemBloc, child) {
+        final colorScheme = Theme.of(context).colorScheme;
+        final textTheme = Theme.of(context).textTheme;
 
-    if (!osemBloc.isAuthenticated || osemBloc.isAuthenticating) {
-      return const SizedBox.shrink();
-    }
+        if (!osemBloc.isAuthenticated || osemBloc.isAuthenticating) {
+          return const SizedBox.shrink();
+        }
 
-    return StreamBuilder<SenseBox?>(
-      stream: osemBloc.senseBoxStream,
-      initialData: osemBloc.selectedSenseBox,
-      builder: (context, snapshot) {
-        final selectedBox = snapshot.data;
-        final bool hasError = snapshot.hasError;
-        final bool noBox = selectedBox == null;
+        return StreamBuilder<SenseBox?>(
+          stream: osemBloc.senseBoxStream,
+          initialData: osemBloc.selectedSenseBox,
+          builder: (context, snapshot) {
+            final selectedBox = snapshot.data;
+            final bool hasError = snapshot.hasError;
+            final bool noBox = selectedBox == null;
 
-        Color textColor = hasError
-            ? colorScheme.onErrorContainer
-            : Theme.of(context).colorScheme.onTertiaryContainer;
-        IconData icon = hasError
-            ? Icons.error
-            : noBox
-                ? Icons.add_box_outlined
-                : Icons.emergency_share_rounded;
-        String label = hasError
-            ? AppLocalizations.of(context)!.generalError
-            : noBox
-                ? AppLocalizations.of(context)!.selectOrCreateBox
-                : selectedBox.name ?? '';
+            Color textColor = hasError
+                ? colorScheme.onErrorContainer
+                : Theme.of(context).colorScheme.onTertiaryContainer;
+            IconData icon = hasError
+                ? Icons.error
+                : noBox
+                    ? Icons.add_box_outlined
+                    : Icons.emergency_share_rounded;
+            String label = hasError
+                ? AppLocalizations.of(context)!.generalError
+                : noBox
+                    ? AppLocalizations.of(context)!.selectOrCreateBox
+                    : selectedBox.name ?? '';
 
-        return InkWell(
-          onTap: () => showSenseBoxSelection(context, osemBloc),
-          child: Container(
-            width: double.infinity,
-            constraints: const BoxConstraints(minHeight: 48),
-            decoration: BoxDecoration(
-              color: hasError
-                  ? colorScheme.errorContainer
-                  : Theme.of(context).colorScheme.tertiary,
-              borderRadius: BorderRadius.circular(borderRadiusSmall),
-              border: Border.all(
-                color: hasError
-                    ? colorScheme.outlineVariant
-                    : Theme.of(context).colorScheme.tertiary,
-                width: 1.0,
-                style: BorderStyle.solid,
+            return InkWell(
+              onTap: () => showSenseBoxSelection(context, osemBloc),
+              child: Container(
+                width: double.infinity,
+                constraints: const BoxConstraints(minHeight: 48),
+                decoration: BoxDecoration(
+                  color: hasError
+                      ? colorScheme.errorContainer
+                      : Theme.of(context).colorScheme.tertiary,
+                  borderRadius: BorderRadius.circular(borderRadiusSmall),
+                  border: Border.all(
+                    color: hasError
+                        ? colorScheme.outlineVariant
+                        : Theme.of(context).colorScheme.tertiary,
+                    width: 1.0,
+                    style: BorderStyle.solid,
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: colorScheme.shadow.withOpacity(0.03),
+                      blurRadius: 1.5,
+                      offset: const Offset(0, 1),
+                    ),
+                  ],
+                ),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    // Icon in a small circle background
+                    SizedBox(
+                      height: 24,
+                      width: 24,
+                      child: Center(
+                        child: Icon(
+                          icon,
+                          color: hasError
+                              ? colorScheme.onErrorContainer
+                              : Theme.of(context)
+                                  .colorScheme
+                                  .onTertiaryContainer,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    // Title
+                    Expanded(
+                      child: Text(
+                        label,
+                        style: textTheme.bodyLarge?.copyWith(
+                          color: textColor,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                      ),
+                    ),
+                    // Optional description (for error or noBox)
+                    if (hasError)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 8.0),
+                        child: Icon(Icons.refresh,
+                            color: colorScheme.onErrorContainer, size: 16),
+                      )
+                    else if (noBox)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 8.0),
+                        child: Icon(Icons.arrow_forward,
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onTertiaryContainer,
+                            size: 16),
+                      ),
+                  ],
+                ),
               ),
-              boxShadow: [
-                BoxShadow(
-                  color: colorScheme.shadow.withOpacity(0.03),
-                  blurRadius: 1.5,
-                  offset: const Offset(0, 1),
-                ),
-              ],
-            ),
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                // Icon in a small circle background
-                SizedBox(
-                  height: 24,
-                  width: 24,
-                  child: Center(
-                    child: Icon(
-                      icon,
-                      color: hasError
-                          ? colorScheme.onErrorContainer
-                          : Theme.of(context).colorScheme.onTertiaryContainer,
-                      size: 20,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                // Title
-                Expanded(
-                  child: Text(
-                    label,
-                    style: textTheme.bodyLarge?.copyWith(
-                      color: textColor,
-                      fontWeight: FontWeight.w600,
-                    ),
-                    maxLines: 1,
-                  ),
-                ),
-                // Optional description (for error or noBox)
-                if (hasError)
-                  Padding(
-                    padding: const EdgeInsets.only(left: 8.0),
-                    child: Icon(Icons.refresh,
-                        color: colorScheme.onErrorContainer, size: 16),
-                  )
-                else if (noBox)
-                  Padding(
-                    padding: const EdgeInsets.only(left: 8.0),
-                    child: Icon(Icons.arrow_forward,
-                        color:
-                            Theme.of(context).colorScheme.onTertiaryContainer,
-                        size: 16),
-                  ),
-              ],
-            ),
-          ),
+            );
+          },
         );
       },
     );

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -13,6 +13,7 @@ import 'package:sensebox_bike/services/isar_service/isar_provider.dart';
 import 'package:sensebox_bike/services/isar_service/sensor_service.dart';
 import 'package:sensebox_bike/services/isar_service/track_service.dart';
 import 'package:sensebox_bike/services/tag_service.dart';
+import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/blocs/geolocation_bloc.dart';
 import 'package:sensebox_bike/sensors/sensor.dart' as sensors;
@@ -20,6 +21,7 @@ import 'package:sensebox_bike/sensors/sensor.dart' as sensors;
 class MockIsarProvider extends Mock implements IsarProvider {}
 
 class MockTagService extends Mock implements TagService {}
+class MockErrorService extends Mock implements ErrorService {}
 class MockIsarService extends Mock implements IsarService {
   final MockTrackService mockTrackService = MockTrackService();
 
@@ -60,6 +62,11 @@ class MockOpenSenseMapBloc extends Mock
 
   @override
   Future<void> logout() async {
+    isAuthenticated = false;
+  }
+
+  @override
+  Future<void> markAuthenticationFailed() async {
     isAuthenticated = false;
   }
 

--- a/test/services/direct_upload_service_test.dart
+++ b/test/services/direct_upload_service_test.dart
@@ -7,9 +7,11 @@ import 'package:sensebox_bike/services/direct_upload_service.dart';
 import 'package:sensebox_bike/services/opensensemap_service.dart';
 import 'package:sensebox_bike/services/custom_exceptions.dart';
 import 'package:sensebox_bike/blocs/settings_bloc.dart';
+import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
 
 class MockOpenSenseMapService extends Mock implements OpenSenseMapService {}
 class MockSettingsBloc extends Mock implements SettingsBloc {}
+class MockOpenSenseMapBloc extends Mock implements OpenSenseMapBloc {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -111,28 +113,30 @@ void main() {
     late DirectUploadService directUploadService;
     late MockOpenSenseMapService mockOpenSenseMapService;
     late MockSettingsBloc mockSettingsBloc;
+    late MockOpenSenseMapBloc mockOpenSenseMapBloc;
     late SenseBox mockSenseBox;
 
     setUp(() {
       mockOpenSenseMapService = MockOpenSenseMapService();
       mockSettingsBloc = MockSettingsBloc();
-      
-      mockSenseBox = SenseBox(
-        sId: 'test-sensebox-id',
-        sensors: [
+      mockOpenSenseMapBloc = MockOpenSenseMapBloc();
+      mockSenseBox = SenseBox()
+        ..sId = 'test-sensebox-id'
+        ..name = 'Test SenseBox'
+        ..sensors = [
           Sensor()
-            ..id = 'temp-sensor-id'
+            ..id = 'temperature-sensor-id'
             ..title = 'Temperature',
           Sensor()
             ..id = 'speed-sensor-id'
             ..title = 'Speed',
-        ],
-      );
+        ];
 
       directUploadService = DirectUploadService(
         openSenseMapService: mockOpenSenseMapService,
         settingsBloc: mockSettingsBloc,
         senseBox: mockSenseBox,
+        openSenseMapBloc: mockOpenSenseMapBloc,
       );
     });
 

--- a/test/services/direct_upload_service_test.dart
+++ b/test/services/direct_upload_service_test.dart
@@ -212,6 +212,9 @@ void main() {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
 
+      // Setup mock to be authenticated
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
       final gpsBuffer = [
         GeolocationData()
           ..latitude = 10.0
@@ -247,6 +250,9 @@ void main() {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
 
+      // Setup mock to be authenticated
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
       // Setup mock to throw temporary authentication error
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
           .thenThrow(Exception('Token refreshed, retrying'));
@@ -278,6 +284,9 @@ void main() {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
 
+      // Setup mock to be authenticated initially
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
       // Test with "No refresh token found" error
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
           .thenThrow(Exception('No refresh token found'));
@@ -298,7 +307,7 @@ void main() {
 
       directUploadService.addGroupedDataForUpload(groupedData, gpsBuffer);
       await directUploadService.uploadRemainingBufferedData();
-
+      
       // Service should be disabled for permanent authentication failures
       expect(directUploadService.isEnabled, false);
     });
@@ -308,6 +317,9 @@ void main() {
         () async {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
+
+      // Setup mock to be authenticated initially
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
       // Test with "Authentication failed - user needs to re-login" error
       when(() => mockOpenSenseMapService.uploadData(any(), any())).thenThrow(
@@ -340,6 +352,9 @@ void main() {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
 
+      // Setup mock to be authenticated initially
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
       // Test with "403 Forbidden" error - should be treated as client error
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
           .thenThrow(Exception('Client error 403: Forbidden'));
@@ -371,6 +386,9 @@ void main() {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
 
+      // Setup mock to be authenticated initially
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
       // Test with "Failed to refresh token" error
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
           .thenThrow(Exception('Failed to refresh token: Network error'));
@@ -399,6 +417,9 @@ void main() {
     test('remains enabled after temporary server errors', () async {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
+
+      // Setup mock to be authenticated
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
       // Setup mock to throw temporary server error
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
@@ -429,6 +450,9 @@ void main() {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
 
+      // Setup mock to be authenticated
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
       // Setup mock to throw rate limiting error
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
           .thenThrow(TooManyRequestsException(30));
@@ -457,6 +481,9 @@ void main() {
     test('remains enabled after successful upload', () async {
       directUploadService.enable();
       expect(directUploadService.isEnabled, true);
+
+      // Setup mock to be authenticated
+      when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
       // Setup mock to succeed
       when(() => mockOpenSenseMapService.uploadData(any(), any()))
@@ -489,6 +516,9 @@ void main() {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
 
+        // Setup mock to be authenticated
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
         // Setup mock to throw 429 rate limiting error
         when(() => mockOpenSenseMapService.uploadData(any(), any()))
             .thenThrow(TooManyRequestsException(30));
@@ -519,6 +549,9 @@ void main() {
       test('handles 502 server error correctly', () async {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
+
+        // Setup mock to be authenticated
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
         // Setup mock to throw 502 server error
         when(() => mockOpenSenseMapService.uploadData(any(), any()))
@@ -553,6 +586,9 @@ void main() {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
 
+        // Setup mock to be authenticated initially
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
         // Setup mock to throw permanent authentication error
         when(() => mockOpenSenseMapService.uploadData(any(), any())).thenThrow(
             Exception('Authentication failed - user needs to re-login'));
@@ -586,6 +622,9 @@ void main() {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
 
+        // Setup mock to be authenticated
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
         // Setup mock to throw token refresh error
         when(() => mockOpenSenseMapService.uploadData(any(), any()))
             .thenThrow(Exception('Token refreshed, retrying'));
@@ -617,6 +656,9 @@ void main() {
           () async {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
+
+        // Setup mock to be authenticated initially
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
         // Setup mock to throw "Not authenticated" error
         when(() => mockOpenSenseMapService.uploadData(any(), any()))
@@ -651,6 +693,9 @@ void main() {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
 
+        // Setup mock to be authenticated
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
+
         // Setup mock to throw timeout error
         when(() => mockOpenSenseMapService.uploadData(any(), any())).thenThrow(
             TimeoutException('Upload timeout', const Duration(seconds: 30)));
@@ -681,6 +726,9 @@ void main() {
       test('handles 404 client error correctly', () async {
         directUploadService.enable();
         expect(directUploadService.isEnabled, true);
+
+        // Setup mock to be authenticated initially
+        when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
         // Setup mock to throw 404 client error
         when(() => mockOpenSenseMapService.uploadData(any(), any()))
@@ -724,6 +772,9 @@ void main() {
         for (final error in temporaryErrors) {
           directUploadService.enable();
           expect(directUploadService.isEnabled, true);
+
+          // Setup mock to be authenticated
+          when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
           when(() => mockOpenSenseMapService.uploadData(any(), any()))
               .thenThrow(
@@ -771,6 +822,9 @@ void main() {
         for (final error in permanentAuthErrors) {
           directUploadService.enable();
           expect(directUploadService.isEnabled, true);
+
+          // Setup mock to be authenticated initially
+          when(() => mockOpenSenseMapBloc.isAuthenticated).thenReturn(true);
 
           when(() => mockOpenSenseMapService.uploadData(any(), any()))
               .thenThrow(Exception(error));

--- a/test/services/direct_upload_service_test.dart
+++ b/test/services/direct_upload_service_test.dart
@@ -120,6 +120,10 @@ void main() {
       mockOpenSenseMapService = MockOpenSenseMapService();
       mockSettingsBloc = MockSettingsBloc();
       mockOpenSenseMapBloc = MockOpenSenseMapBloc();
+      
+      // Setup mock for markAuthenticationFailed method
+      when(() => mockOpenSenseMapBloc.markAuthenticationFailed()).thenAnswer((_) async {});
+      
       mockSenseBox = SenseBox()
         ..sId = 'test-sensebox-id'
         ..name = 'Test SenseBox'

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -120,11 +120,13 @@ void mockSenseBoxInSharedPreferences() {
 }
 
 TrackData createMockTrackData() {
-  return TrackData();
+  return TrackData()
+    ..id = Isar.autoIncrement;
 }
 
 GeolocationData createMockGeolocationData(TrackData trackData) {
   return GeolocationData()
+    ..id = Isar.autoIncrement
     ..latitude = 52.5200
     ..longitude = 13.4050
     ..timestamp = DateTime.now()
@@ -134,6 +136,7 @@ GeolocationData createMockGeolocationData(TrackData trackData) {
 
 SensorData createMockSensorData(GeolocationData geolocationData) {
   return SensorData()
+    ..id = Isar.autoIncrement
     ..title = 'temperature'
     ..value = 25.0
     ..attribute = null

--- a/test/ui/screens/settings_screen_test.dart
+++ b/test/ui/screens/settings_screen_test.dart
@@ -307,6 +307,8 @@ void main() {
     await tester.tap(find.text('Privacy Policy'));
     await tester.pumpAndSettle();
 
+    // The error should be handled gracefully and the screen should remain visible
+    // The test should not crash even when URL launch fails
     expect(find.byType(SettingsScreen), findsOneWidget);
   });
 


### PR DESCRIPTION
Closes #

### Detailed Changes
*   Fixes scenario, when authentication token cannot be refreshed after track recording start
    * updates box selection area to reflect authentication status
    * allow data saving locally even if data upload fails
*   Store sensor data for temporal network issues
   * handle network issues along with 429 and temporal authentication issues in OpenSenseMapService

### Testing
1. 
- Open app and start track recording with data upload
- Uncomment code to imitate authentication token expiry (see comments from Copilot below)
=> data upload should not be interrupted
2. 
- Open app and start track recording with data upload
- Uncomment code to imitate permanent authentication error (see comments from Copilot below)
=>
- You should see corresponding error message

- Wait some time and stop recording manually
=> All track data should be stored locally

3. 
- Open app and start track recording with data upload
- Turn off internet on your phone for a minute and turn it back on
=> After a while all sensor data should be uploaded to the opensensemap

4.
- Decrease buffer size to 5
- Start track recording with upload
=> You should see trimming messages in Sentry
### Checklist before requesting a review

[X] I have performed a self-review of my code
[X] I have added or updated tests
[ ] I have added or updated relevant documentation

### Additional Information
