### PR TITLE
Add "no tracks yet" message to tracks screen 

### DIFF
--- a/lib/ui/screens/tracks_screen.dart
+++ b/lib/ui/screens/tracks_screen.dart
@@ -4,7 +4,9 @@ import 'package:sensebox_bike/blocs/recording_bloc.dart';
 import 'package:sensebox_bike/models/track_data.dart';
 import 'package:flutter/material.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
+import 'package:sensebox_bike/ui/widgets/common/button_with_loader.dart';
 import 'package:sensebox_bike/ui/widgets/common/no_tracks_message.dart';
+import 'package:sensebox_bike/ui/widgets/common/custom_divider.dart';
 import 'package:sensebox_bike/ui/widgets/common/screen_wrapper.dart';
 import 'package:sensebox_bike/ui/widgets/track/track_list_item.dart';
 import 'package:sensebox_bike/l10n/app_localizations.dart';
@@ -42,9 +44,6 @@ class TracksScreenState extends State<TracksScreen> {
       }
     };
     _recordingBloc.isRecordingNotifier.addListener(_recordingListener!);
-
-    // Add scroll listener for pagination
-    _scrollController.addListener(_onScroll);
 
     _fetchInitialTracks();
   }
@@ -105,15 +104,6 @@ class TracksScreenState extends State<TracksScreen> {
     });
   }
 
-  void _onScroll() {
-    if (_scrollController.position.pixels >=
-            _scrollController.position.maxScrollExtent - 100 &&
-        _hasMoreTracks &&
-        !_isLoading) {
-      _loadMoreTracks();
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
@@ -125,52 +115,66 @@ class TracksScreenState extends State<TracksScreen> {
         children: [
           Expanded(
             child: RefreshIndicator(
-              color: Theme.of(context).colorScheme.primaryFixedDim,
-              onRefresh: _handleRefresh,
-              child: _displayedTracks.isEmpty
-                  ? const NoTracksMessage()
-                  : ScrollbarTheme(
-                      data: ScrollbarThemeData(
-                        thumbColor: WidgetStateProperty.all(
-                            colorScheme.primaryFixedDim),
-                      ),
-                      child: Scrollbar(
-                        controller: _scrollController,
-                        thumbVisibility: true,
-                        thickness: 2,
-                        child: ListView.builder(
-                          controller: _scrollController,
-                          padding: const EdgeInsets.all(16.0),
-                          itemCount: _displayedTracks.length +
-                              (_hasMoreTracks ? 1 : 0),
-                          itemBuilder: (context, index) {
-                            if (index == _displayedTracks.length) {
-                              // Show loading indicator for pagination
-                              return _isLoading
-                                  ? const Padding(
-                                      padding: EdgeInsets.all(16.0),
-                                      child: Center(
-                                        child: CircularProgressIndicator(),
-                                      ),
-                                    )
-                                  : const SizedBox.shrink();
-                            }
-
-                            final track = _displayedTracks[index];
-                            return TrackListItem(
-                              track: track,
-                              onDismissed: () async {
-                                await _isarService.trackService
-                                    .deleteTrack(track.id);
-                                _handleRefresh();
+                  color: Theme.of(context).colorScheme.primaryFixedDim,
+                  onRefresh: _handleRefresh,
+                  child: _displayedTracks.isEmpty
+                      ? NoTracksMessage()
+                      : ScrollbarTheme(
+                          data: ScrollbarThemeData(
+                            thumbColor: WidgetStateProperty.all(
+                                colorScheme.primaryFixedDim),
+                          ),
+                          child: Scrollbar(
+                            controller: _scrollController,
+                            thumbVisibility: true,
+                            thickness: 2,
+                            child: ListView.separated(
+                              separatorBuilder: (context, index) =>
+                                  CustomDivider(
+                                showDivider:
+                                    !(index == _displayedTracks.length - 1 &&
+                                        _hasMoreTracks),
+                              ),
+                              controller: _scrollController,
+                              itemCount: _hasMoreTracks
+                                  ? _displayedTracks.length +
+                                      1 // Add 1 for "Load More"
+                                  : _displayedTracks
+                                      .length, // No "Load More" button
+                              itemBuilder: (context, index) {
+                                if (index < _displayedTracks.length) {
+                                  TrackData track = _displayedTracks[index];
+                                  return TrackListItem(
+                                    track: track,
+                                    onDismissed: () async {
+                                      await _isarService.trackService
+                                          .deleteTrack(track.id);
+                                      ScaffoldMessenger.of(context)
+                                          .showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                              localizations.tracksTrackDeleted),
+                                        ),
+                                      );
+                                      _handleRefresh();
+                                    },
+                                  );
+                                } else {
+                                  return Center(
+                                    child: ButtonWithLoader(
+                                      isLoading: _isLoading,
+                                      onPressed:
+                                          _isLoading ? null : _loadMoreTracks,
+                                      text: AppLocalizations.of(context)!
+                                          .loadMore,
+                                      width: 0.6,
+                                    ),
+                                  );
+                                }
                               },
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-            ),
-          ),
+                            ),
+                          ),
+                        ))),
         ],
       ),
     );

--- a/lib/ui/screens/tracks_screen.dart
+++ b/lib/ui/screens/tracks_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/ui/widgets/common/button_with_loader.dart';
 import 'package:sensebox_bike/ui/widgets/common/custom_divider.dart';
+import 'package:sensebox_bike/ui/widgets/common/no_tracks_message.dart';
 import 'package:sensebox_bike/ui/widgets/common/screen_wrapper.dart';
 import 'package:sensebox_bike/ui/widgets/track/track_list_item.dart';
 import 'package:sensebox_bike/l10n/app_localizations.dart';
@@ -125,44 +126,46 @@ class TracksScreenState extends State<TracksScreen> {
                     controller: _scrollController,
                     thumbVisibility: true,
                     thickness: 2,
-                    child: ListView.separated(
-                      separatorBuilder: (context, index) => CustomDivider(
-                        showDivider: !(index == _displayedTracks.length - 1 &&
-                            _hasMoreTracks),
-                      ),
-                      controller: _scrollController,
-                      itemCount: _hasMoreTracks
-                          ? _displayedTracks.length + 1 // Add 1 for "Load More"
-                          : _displayedTracks.length, // No "Load More" button
-                      itemBuilder: (context, index) {
-                        if (index < _displayedTracks.length) {
-                          TrackData track = _displayedTracks[index];
-                          return TrackListItem(
-                            track: track,
-                            onDismissed: () async {
-                              await _isarService.trackService
-                                  .deleteTrack(track.id);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(
-                                  content:
-                                      Text(localizations.tracksTrackDeleted),
-                                ),
-                              );
-                              _handleRefresh();
-                            },
-                          );
-                        } else {
-                          return Center(
-                            child: ButtonWithLoader(
-                              isLoading: _isLoading,
-                              onPressed: _isLoading ? null : _loadMoreTracks,
-                              text: AppLocalizations.of(context)!.loadMore,
-                              width: 0.6,
+                    child: _displayedTracks.isEmpty && !_isLoading
+                        ? const NoTracksMessage()
+                        : ListView.separated(
+                            separatorBuilder: (context, index) => CustomDivider(
+                              showDivider: !(index == _displayedTracks.length - 1 &&
+                                  _hasMoreTracks),
                             ),
-                          );
-                        }
-                      },
-                    ),
+                            controller: _scrollController,
+                            itemCount: _hasMoreTracks
+                                ? _displayedTracks.length + 1 // Add 1 for "Load More"
+                                : _displayedTracks.length, // No "Load More" button
+                            itemBuilder: (context, index) {
+                              if (index < _displayedTracks.length) {
+                                TrackData track = _displayedTracks[index];
+                                return TrackListItem(
+                                  track: track,
+                                  onDismissed: () async {
+                                    await _isarService.trackService
+                                        .deleteTrack(track.id);
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content:
+                                            Text(localizations.tracksTrackDeleted),
+                                      ),
+                                    );
+                                    _handleRefresh();
+                                  },
+                                );
+                              } else {
+                                return Center(
+                                  child: ButtonWithLoader(
+                                    isLoading: _isLoading,
+                                    onPressed: _isLoading ? null : _loadMoreTracks,
+                                    text: AppLocalizations.of(context)!.loadMore,
+                                    width: 0.6,
+                                  ),
+                                );
+                              }
+                            },
+                          ),
                   ),
                 )),
           ),

--- a/lib/ui/widgets/common/no_tracks_message.dart
+++ b/lib/ui/widgets/common/no_tracks_message.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:sensebox_bike/l10n/app_localizations.dart';
+
+/// A centered widget that displays a message when no tracks are available.
+/// Used to inform users that they haven't recorded any tracks yet.
+class NoTracksMessage extends StatelessWidget {
+  const NoTracksMessage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.route_outlined,
+              size: 64,
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              localizations.tracksNoTracks,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -5,6 +5,7 @@ import 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
 import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
 import 'package:sensebox_bike/blocs/track_bloc.dart';
 import 'package:sensebox_bike/blocs/settings_bloc.dart';
+import 'package:sensebox_bike/blocs/recording_bloc.dart';
 import 'package:sensebox_bike/models/sensor_data.dart';
 import 'package:sensebox_bike/models/sensebox.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
@@ -85,6 +86,14 @@ class MockOpenSenseMapBloc extends Mock
 class MockSettingsBloc extends Mock
     with ChangeNotifier
     implements SettingsBloc {}
+
+class MockRecordingBloc extends Mock implements RecordingBloc {
+  @override
+  bool get isRecording => false;
+
+  @override
+  ValueNotifier<bool> get isRecordingNotifier => ValueNotifier<bool>(false);
+}
 
 class MockSensor extends Mock implements sensors.Sensor {}
 class FakeSensorData extends Fake implements SensorData {}

--- a/test/ui/screens/tracks_screen_test.dart
+++ b/test/ui/screens/tracks_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:sensebox_bike/services/isar_service/track_service.dart';
 import 'package:sensebox_bike/ui/screens/tracks_screen.dart';
 import 'package:sensebox_bike/l10n/app_localizations.dart';
 import 'package:sensebox_bike/ui/widgets/track/track_list_item.dart';
+import 'package:sensebox_bike/ui/widgets/common/no_tracks_message.dart';
 
 class MockIsarService extends Mock implements IsarService {}
 
@@ -32,9 +33,12 @@ void main() {
 
   Future<void> pumpTracksScreen(
     WidgetTester tester, {
-    required Future<List<TrackData>> tracksFuture,
+    required List<TrackData> tracks,
   }) async {
-    when(() => mockTrackService.getAllTracks()).thenAnswer((_) => tracksFuture);
+    when(() => mockIsarService.getTracksPaginated(
+          offset: any(named: 'offset'),
+          limit: any(named: 'limit'),
+        )).thenAnswer((_) async => tracks);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -47,10 +51,23 @@ void main() {
       ),
     );
 
+    // Allow the initial loading to complete
     await tester.pump();
   }
 
   group('TracksScreen', () {
+    testWidgets('displays no tracks message when no tracks are available',
+        (WidgetTester tester) async {
+      await pumpTracksScreen(tester, tracks: []);
+
+      // Wait for the loading to complete
+      await tester.pump();
+
+      // Should show the NoTracksMessage widget
+      expect(find.byType(NoTracksMessage), findsOneWidget);
+      expect(find.text('No tracks available'), findsOneWidget);
+    });
+
     // TBD: fix tests for loading tracks
     // testWidgets('displays loading indicator while tracks are loading',
     //     (WidgetTester tester) async {

--- a/test/ui/widgets/common/no_tracks_message_test.dart
+++ b/test/ui/widgets/common/no_tracks_message_test.dart
@@ -34,8 +34,9 @@ void main() {
         ),
       );
 
-      // Check if the widget is wrapped in a Center widget
-      expect(find.byType(Center), findsOneWidget);
+      expect(find.byType(NoTracksMessage), findsOneWidget);
+      expect(find.byIcon(Icons.route_outlined), findsOneWidget);
+      expect(find.text('No tracks available'), findsOneWidget);
     });
   });
 }

--- a/test/ui/widgets/common/no_tracks_message_test.dart
+++ b/test/ui/widgets/common/no_tracks_message_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sensebox_bike/ui/widgets/common/no_tracks_message.dart';
+import 'package:sensebox_bike/l10n/app_localizations.dart';
+
+void main() {
+  group('NoTracksMessage', () {
+    testWidgets('displays correct message and icon', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: NoTracksMessage(),
+          ),
+        ),
+      );
+
+      // Check if the route icon is displayed
+      expect(find.byIcon(Icons.route_outlined), findsOneWidget);
+
+      // Check if the no tracks message is displayed
+      expect(find.text('No tracks available'), findsOneWidget);
+    });
+
+    testWidgets('is properly centered', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: NoTracksMessage(),
+          ),
+        ),
+      );
+
+      // Check if the widget is wrapped in a Center widget
+      expect(find.byType(Center), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #134 

### Detailed Changes
*   Adds no tracks widget
*   Adds corresponding translations and tests

### Testing
- delete all tracks and navigate tracks screen OR
- update code to display no tracks widget
=> you should see screen below

### Checklist before requesting a review

[ ] I have performed a self-review of my code
[X] I have added or updated tests
[ ] I have added or updated relevant 

### Additional Information

<img width="300" alt="1000008325" src="https://github.com/user-attachments/assets/e4283ebf-7223-4ce1-a771-80205b31f2ed" />
<img width="300"  alt="Screenshot_20250814-090634" src="https://github.com/user-attachments/assets/59577aa5-830e-477f-9381-44364f623b70" />
documentation
