### PR TITLE
Chore: Prevent track recording when location permissions are denied

### DIFF
--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -10,6 +10,7 @@ import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/services/direct_upload_service.dart';
 import 'package:sensebox_bike/services/opensensemap_service.dart';
+import 'package:sensebox_bike/services/permission_service.dart';
 
 class RecordingBloc with ChangeNotifier {
   final BleBloc bleBloc;
@@ -67,6 +68,15 @@ class RecordingBloc with ChangeNotifier {
 
   void startRecording() async {
     if (_isRecording) return;
+
+    try {
+      // Check location permissions before starting recording
+      await PermissionService.ensureLocationPermissionsGranted();
+    } catch (e) {
+      // Don't start recording if location permissions are not granted
+      ErrorService.handleError(e, StackTrace.current);
+      return;
+    }
 
     _isRecording = true;
     _isRecordingNotifier.value = true; 

--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -66,7 +66,7 @@ class RecordingBloc with ChangeNotifier {
     notifyListeners(); 
   }
 
-  void startRecording() async {
+  Future<void> startRecording() async {
     if (_isRecording) return;
 
     try {
@@ -106,7 +106,7 @@ class RecordingBloc with ChangeNotifier {
     notifyListeners();
   }
 
-  void stopRecording() async {
+  Future<void> stopRecording() async {
     if (!_isRecording) return;
 
     _isRecording = false;

--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -75,6 +75,7 @@ class RecordingBloc with ChangeNotifier {
     } catch (e) {
       // Don't start recording if location permissions are not granted
       ErrorService.handleError(e, StackTrace.current);
+      notifyListeners();
       return;
     }
 

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -162,7 +162,7 @@
     "noCampaignsAvailable": "Keine Kampagnen verfügbar",
     "loginScreenTitle": "openSenseMap Konto",
     "connectionButtonEnableBluetooth": "Bluetooth aktivieren",
-    "errorNoLocationAccess": "Um Tracks aufzuzeichnen, erlauben Sie bitte der App in den Telefoneinstellungen den Zugriff auf den aktuellen Standort des Geräts.",
+    "errorNoLocationAccess": "Standortdienste sind deaktiviert oder der Zugriff ist verweigert. Um Tracks aufzuzeichnen, aktivieren Sie bitte die Standortdienste und erlauben Sie der App in den Telefoneinstellungen den Zugriff auf Ihren Standort.",
     "errorNoScanAccess": "Um eine Verbindung mit senseBox herzustellen, erlauben Sie bitte der App in den Telefoneinstellungen, nach Geräten in der Nähe zu scannen.",
     "errorNoSenseBoxSelected": "Um den Upload von Sensordaten in die Cloud zu erlauben, melden Sie sich bitte bei Ihrem openSenseMap-Konto an und aktivieren Sie das Kästchen.",
     "errorExportDirectoryAccess": "Bitte erlaube dieser App in den Telefoneinstellungen den Zugriff auf den externen Speicher.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -162,7 +162,7 @@
     "noCampaignsAvailable": "No campaigns available",
     "loginScreenTitle": "openSenseMap Account",
     "connectionButtonEnableBluetooth": "Enable Bluetooth",
-    "errorNoLocationAccess": "To record tracks, please allow the app to access the device's current location in the phone settings.",
+    "errorNoLocationAccess": "Location services are disabled or access is denied. To record tracks, please enable location services and allow the app to access your location in the phone settings.",
     "errorNoScanAccess": "To connect with senseBox, please allow the app to scan for nearby devices in the phone settings.",
     "errorNoSenseBoxSelected": "To allow upload of sensor data to the cloud, please log in to your openSenseMap account and select the box.",
     "errorExportDirectoryAccess": "Error accessing export directory. Please make sure the app has permission to access the storage.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -826,7 +826,7 @@ abstract class AppLocalizations {
   /// No description provided for @errorNoLocationAccess.
   ///
   /// In en, this message translates to:
-  /// **'To record tracks, please allow the app to access the device\'s current location in the phone settings.'**
+  /// **'Location services are disabled or access is denied. To record tracks, please enable location services and allow the app to access your location in the phone settings.'**
   String get errorNoLocationAccess;
 
   /// No description provided for @errorNoScanAccess.

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -391,7 +391,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get connectionButtonEnableBluetooth => 'Bluetooth aktivieren';
 
   @override
-  String get errorNoLocationAccess => 'Um Tracks aufzuzeichnen, erlauben Sie bitte der App in den Telefoneinstellungen den Zugriff auf den aktuellen Standort des Geräts.';
+  String get errorNoLocationAccess => 'Standortdienste sind deaktiviert oder der Zugriff ist verweigert. Um Tracks aufzuzeichnen, aktivieren Sie bitte die Standortdienste und erlauben Sie der App in den Telefoneinstellungen den Zugriff auf Ihren Standort.';
 
   @override
   String get errorNoScanAccess => 'Um eine Verbindung mit senseBox herzustellen, erlauben Sie bitte der App in den Telefoneinstellungen, nach Geräten in der Nähe zu scannen.';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -391,7 +391,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get connectionButtonEnableBluetooth => 'Enable Bluetooth';
 
   @override
-  String get errorNoLocationAccess => 'To record tracks, please allow the app to access the device\'s current location in the phone settings.';
+  String get errorNoLocationAccess => 'Location services are disabled or access is denied. To record tracks, please enable location services and allow the app to access your location in the phone settings.';
 
   @override
   String get errorNoScanAccess => 'To connect with senseBox, please allow the app to scan for nearby devices in the phone settings.';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -391,7 +391,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get connectionButtonEnableBluetooth => 'Ativar Bluetooth';
 
   @override
-  String get errorNoLocationAccess => 'Para gravar faixas, permita que a aplicação aceda à localização atual do dispositivo nas definições do telefone.';
+  String get errorNoLocationAccess => 'Os serviços de localização estão desativados ou o acesso é negado. Para gravar faixas, ative os serviços de localização e permita que a aplicação aceda à sua localização nas definições do telefone.';
 
   @override
   String get errorNoScanAccess => 'Para se conectar à SenseBox, permita que a aplicação procure dispositivos próximos nas definições do telemóvel.';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -162,7 +162,7 @@
     "noCampaignsAvailable": "Não há campanhas disponíveis",
     "loginScreenTitle": "openSenseMap Conta",
     "connectionButtonEnableBluetooth": "Ativar Bluetooth",
-    "errorNoLocationAccess": "Para gravar faixas, permita que a aplicação aceda à localização atual do dispositivo nas definições do telefone.",
+    "errorNoLocationAccess": "Os serviços de localização estão desativados ou o acesso é negado. Para gravar faixas, ative os serviços de localização e permita que a aplicação aceda à sua localização nas definições do telefone.",
     "errorNoScanAccess": "Para se conectar à SenseBox, permita que a aplicação procure dispositivos próximos nas definições do telemóvel.",
     "errorNoSenseBoxSelected": "Para permitir o envio de dados do sensor para a nuvem, inicie sessão na sua conta do openSenseMap e selecione a caixa.",
     "errorExportDirectoryAccess": "Erro ao acessar o diretório de exportação. Por favor, verifique se o aplicativo tem permissão para acessar o armazenamento.",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -111,9 +111,14 @@ class SenseBoxBikeApp extends StatelessWidget {
 
         final fullId = "senseBox:bike [$id]";
         print('Connecting to $fullId');
-        await bleBloc.connectToId(fullId, context);
-        await Future.delayed(const Duration(seconds: 2));
-        recordingBloc.startRecording();
+        try {
+          await bleBloc.connectToId(fullId, context);
+          await Future.delayed(const Duration(seconds: 2));
+          await recordingBloc.startRecording();
+        } catch (e) {
+          ErrorService.handleError(e, StackTrace.current, sendToSentry: true);
+        }
+
       }
     });
 

--- a/lib/services/custom_exceptions.dart
+++ b/lib/services/custom_exceptions.dart
@@ -10,7 +10,7 @@ class TooManyRequestsException implements Exception {
 class LocationPermissionDenied implements Exception {
   @override
   String toString() =>
-      'Please allow the current app to access location of the current device in the phone settings.';
+      'Location services are disabled or access is denied. Please enable location services and allow the app to access your location in the phone settings.';
 }
 
 class ScanPermissionDenied implements Exception {

--- a/lib/services/error_service.dart
+++ b/lib/services/error_service.dart
@@ -59,7 +59,7 @@ class ErrorService {
 
     if (error is LocationPermissionDenied) {
       return localizations?.errorNoLocationAccess ??
-          'Please allow the app to access your location in the phone settings.';
+          'Location services are disabled or access is denied. Please enable location services and allow the app to access your location in the phone settings.';
     } else if (error is ScanPermissionDenied) {
       return localizations?.errorNoScanAccess ??
           'Please allow the app to scan nearby devices in the phone settings.';

--- a/lib/services/permission_service.dart
+++ b/lib/services/permission_service.dart
@@ -5,7 +5,7 @@ class PermissionService {
   static Future<void> ensureLocationPermissionsGranted() async {
     bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
     if (!serviceEnabled) {
-      throw Exception('Location services are disabled.');
+      throw LocationPermissionDenied();
     }
 
     LocationPermission permission = await Geolocator.checkPermission();

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -8,7 +8,6 @@ import 'package:sensebox_bike/blocs/sensor_bloc.dart';
 import 'package:sensebox_bike/models/sensebox.dart';
 import 'package:sensebox_bike/theme.dart';
 import 'package:sensebox_bike/services/error_service.dart';
-import 'package:sensebox_bike/services/permission_service.dart';
 import 'package:sensebox_bike/ui/utils/common.dart';
 import 'package:sensebox_bike/ui/widgets/common/loader.dart';
 import 'package:sensebox_bike/ui/widgets/home/ble_device_selection_dialog_widget.dart';
@@ -385,15 +384,10 @@ class _StartStopButton extends StatelessWidget {
           : AppLocalizations.of(context)!.connectionButtonStart),
       icon: Icon(
           recordingBloc.isRecording ? Icons.stop : Icons.fiber_manual_record),
-      onPressed: () async {
-        try {
-          await PermissionService.ensureLocationPermissionsGranted();
-          recordingBloc.isRecording
-              ? recordingBloc.stopRecording()
-              : recordingBloc.startRecording();
-        } catch (e) {
-          ErrorService.handleError(e, StackTrace.current);
-        }
+      onPressed: () {
+        recordingBloc.isRecording
+            ? recordingBloc.stopRecording()
+            : recordingBloc.startRecording();
       },
     );
   }

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -384,10 +384,12 @@ class _StartStopButton extends StatelessWidget {
           : AppLocalizations.of(context)!.connectionButtonStart),
       icon: Icon(
           recordingBloc.isRecording ? Icons.stop : Icons.fiber_manual_record),
-      onPressed: () {
-        recordingBloc.isRecording
-            ? recordingBloc.stopRecording()
-            : recordingBloc.startRecording();
+      onPressed: () async {
+        if (recordingBloc.isRecording) {
+          await recordingBloc.stopRecording();
+        } else {
+          await recordingBloc.startRecording();
+        }
       },
     );
   }

--- a/test/blocs/recording_bloc_test.dart
+++ b/test/blocs/recording_bloc_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart' as geo;
+import 'package:mocktail/mocktail.dart';
+import 'package:sensebox_bike/blocs/recording_bloc.dart';
+import 'package:sensebox_bike/blocs/ble_bloc.dart';
+import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
+import 'package:sensebox_bike/blocs/settings_bloc.dart';
+import 'package:sensebox_bike/blocs/track_bloc.dart';
+import 'package:sensebox_bike/services/isar_service.dart';
+import 'package:sensebox_bike/services/custom_exceptions.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class MockGeolocator extends Mock
+    with MockPlatformInterfaceMixin
+    implements geo.GeolocatorPlatform {}
+
+class MockIsarService extends Mock implements IsarService {}
+
+class MockBleBloc extends Mock implements BleBloc {}
+
+class MockTrackBloc extends Mock implements TrackBloc {}
+
+class MockOpenSenseMapBloc extends Mock implements OpenSenseMapBloc {}
+
+class MockSettingsBloc extends Mock implements SettingsBloc {}
+
+void main() {
+  late MockGeolocator mockGeolocator;
+  late MockIsarService mockIsarService;
+  late MockBleBloc mockBleBloc;
+  late MockTrackBloc mockTrackBloc;
+  late MockOpenSenseMapBloc mockOpenSenseMapBloc;
+  late MockSettingsBloc mockSettingsBloc;
+  late RecordingBloc recordingBloc;
+
+  setUp(() {
+    mockGeolocator = MockGeolocator();
+    mockIsarService = MockIsarService();
+    mockBleBloc = MockBleBloc();
+    mockTrackBloc = MockTrackBloc();
+    mockOpenSenseMapBloc = MockOpenSenseMapBloc();
+    mockSettingsBloc = MockSettingsBloc();
+
+    geo.GeolocatorPlatform.instance = mockGeolocator;
+
+    // Setup mock for senseBoxStream
+    when(() => mockOpenSenseMapBloc.senseBoxStream).thenAnswer(
+      (_) => Stream.value(null),
+    );
+
+    recordingBloc = RecordingBloc(
+      mockIsarService,
+      mockBleBloc,
+      mockTrackBloc,
+      mockOpenSenseMapBloc,
+      mockSettingsBloc,
+    );
+  });
+
+  tearDown(() {
+    recordingBloc.dispose();
+  });
+
+  group('RecordingBloc.startRecording', () {
+    test('should not start recording if location permission is denied', () async {
+      // Setup: location services disabled
+      when(() => mockGeolocator.isLocationServiceEnabled())
+          .thenAnswer((_) async => false);
+
+      // Act
+      await recordingBloc.startRecording();
+
+      // Assert
+      expect(recordingBloc.isRecording, isFalse);
+      verifyNever(() => mockTrackBloc.startNewTrack());
+    });
+
+    test('should not start recording if location permission is denied after request', () async {
+      // Setup: permission denied
+      when(() => mockGeolocator.isLocationServiceEnabled())
+          .thenAnswer((_) async => true);
+      when(() => mockGeolocator.checkPermission())
+          .thenAnswer((_) async => geo.LocationPermission.denied);
+      when(() => mockGeolocator.requestPermission())
+          .thenAnswer((_) async => geo.LocationPermission.denied);
+
+      // Act
+      await recordingBloc.startRecording();
+
+      // Assert
+      expect(recordingBloc.isRecording, isFalse);
+      verifyNever(() => mockTrackBloc.startNewTrack());
+    });
+
+    test('should start recording if location permission is granted', () async {
+      // Setup: permission granted
+      when(() => mockGeolocator.isLocationServiceEnabled())
+          .thenAnswer((_) async => true);
+      when(() => mockGeolocator.checkPermission())
+          .thenAnswer((_) async => geo.LocationPermission.whileInUse);
+      when(() => mockTrackBloc.startNewTrack()).thenAnswer((_) async {});
+      when(() => mockTrackBloc.currentTrack).thenReturn(null);
+
+      // Act
+      await recordingBloc.startRecording();
+
+      // Assert
+      expect(recordingBloc.isRecording, isTrue);
+      verify(() => mockTrackBloc.startNewTrack()).called(1);
+    });
+
+    test('should not start recording twice', () async {
+      // Setup: permission granted
+      when(() => mockGeolocator.isLocationServiceEnabled())
+          .thenAnswer((_) async => true);
+      when(() => mockGeolocator.checkPermission())
+          .thenAnswer((_) async => geo.LocationPermission.whileInUse);
+      when(() => mockTrackBloc.startNewTrack()).thenAnswer((_) async {});
+      when(() => mockTrackBloc.currentTrack).thenReturn(null);
+
+      // Act: start recording twice
+      await recordingBloc.startRecording();
+      await recordingBloc.startRecording();
+
+      // Assert
+      expect(recordingBloc.isRecording, isTrue);
+      verify(() => mockTrackBloc.startNewTrack()).called(1); // Only called once
+    });
+  });
+
+  group('RecordingBloc.stopRecording', () {
+    test('should stop recording', () {
+      // Setup: manually set recording state to true
+      recordingBloc.startRecording();
+
+      // Act
+      recordingBloc.stopRecording();
+
+      // Assert
+      expect(recordingBloc.isRecording, isFalse);
+      expect(recordingBloc.currentTrack, isNull);
+    });
+
+    test('should not fail if called when not recording', () {
+      // Act
+      recordingBloc.stopRecording();
+
+      // Assert
+      expect(recordingBloc.isRecording, isFalse);
+    });
+  });
+}

--- a/test/services/error_service_test.dart
+++ b/test/services/error_service_test.dart
@@ -34,7 +34,7 @@ void main() {
 
         expect(
           message,
-          'To record tracks, please allow the app to access the device\'s current location in the phone settings.',
+          'Location services are disabled or access is denied. To record tracks, please enable location services and allow the app to access your location in the phone settings.',
         );
       });
 
@@ -176,7 +176,7 @@ void main() {
         // Verify that the SnackBar is displayed with the correct message
         expect(
           find.text(
-              'Please allow the app to access your location in the phone settings.'),
+              'Location services are disabled or access is denied. Please enable location services and allow the app to access your location in the phone settings.'),
           findsOneWidget,
         );
       });

--- a/test/services/permission_service_test.dart
+++ b/test/services/permission_service_test.dart
@@ -24,9 +24,7 @@ void main() {
 
       expect(
         () => PermissionService.ensureLocationPermissionsGranted(),
-        throwsA(predicate((e) =>
-            e is Exception &&
-            e.toString().contains('Location services are disabled.'))),
+        throwsA(isA<LocationPermissionDenied>()),
       );
     });
 


### PR DESCRIPTION
Closes #121 

### Detailed Changes
*   Disallows track recording, when app is not granted location permissions
*   When possible, opens system window to grant location permissions, when user hits Start button and shows error message

### Testing
- Disable (temporary) location access permission for the app
- Connect to the box and start track recording
=>
- You should see error message
- You should see system prompt to grant app access permissions

### Checklist before requesting a review

[X] I have performed a self-review of my code
[X] I have added or updated tests
[ ] I have added or updated relevant documentation

### Additional Information
