### PR TITLE
Fix: auth token refresh

### DIFF
--- a/lib/blocs/opensensemap_bloc.dart
+++ b/lib/blocs/opensensemap_bloc.dart
@@ -251,6 +251,7 @@ class OpenSenseMapBloc with ChangeNotifier, WidgetsBindingObserver {
       _isAuthenticated = false;
       _senseBoxController.add(null); // Clear senseBox on logout
       _selectedSenseBox = null;
+      _senseBoxes.clear(); // Clear cached senseboxes
       notifyListeners();
     } catch (e, stack) {
       ErrorService.handleError(e, stack);
@@ -325,9 +326,20 @@ class OpenSenseMapBloc with ChangeNotifier, WidgetsBindingObserver {
 
   @override
   void dispose() {
+    // Remove observer first to prevent any further lifecycle callbacks
     WidgetsBinding.instance.removeObserver(this);
+    
+    // Close stream controller
     _senseBoxController.close();
+    
+    // Dispose value notifier
     _isAuthenticatingNotifier.dispose();
+    
+    // Clear all data structures
+    _senseBoxes.clear();
+    _selectedSenseBox = null;
+    
+    // Call super dispose last
     super.dispose();
   }
 }

--- a/lib/blocs/opensensemap_bloc.dart
+++ b/lib/blocs/opensensemap_bloc.dart
@@ -57,6 +57,8 @@ class OpenSenseMapBloc with ChangeNotifier, WidgetsBindingObserver {
   }
 
   OpenSenseMapBloc() {
+    // Register as observer to handle app lifecycle events
+    WidgetsBinding.instance.addObserver(this);
     _initializeAuth();
   }
 
@@ -323,6 +325,7 @@ class OpenSenseMapBloc with ChangeNotifier, WidgetsBindingObserver {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _senseBoxController.close();
     _isAuthenticatingNotifier.dispose();
     super.dispose();


### PR DESCRIPTION
Closes #

<!-- Briefly describe the purpose of this pull request. What problem does it solve? What feature does it add? -->

This PR fixes a critical authentication issue where users were being logged out when they locked their phone during a ride and then unlocked it to stop recording. The root cause was that the `OpenSenseMapBloc` was not properly registered as a `WidgetsBindingObserver`, preventing it from receiving app lifecycle events needed to maintain authentication state.

### Detailed Changes
<!-- List the specific changes made in this pull request. Be clear and concise. -->
*   **Fixed authentication persistence during phone lock/unlock**: Added `WidgetsBinding.instance.addObserver(this)` in `OpenSenseMapBloc` constructor to register for app lifecycle events
*   **Added proper observer cleanup**: Added `WidgetsBinding.instance.removeObserver(this)` in the dispose method to prevent memory leaks
*   **Enhanced resource management**: Improved the `dispose()` method with better cleanup order and added `_senseBoxes.clear()` in the `logout()` method
*   **Added defensive programming**: Ensured all data structures are properly cleared and nullified during disposal

### Testing
<!-- Describe the testing strategy applied to verify the changes. Include steps to reproduce the changes and validate the solution. -->

**Test Scenario to Reproduce the Fix:**
1. Open the app and log in
2. Create a senseBox and connect to it
3. Start recording a track
4. Lock the phone during the ride
5. Unlock the phone and stop the recording
6. **Expected Result**: User remains authenticated and can continue using the app
7. **Previous Behavior**: User would be logged out and need to re-authenticate

**Additional Testing:**
- Verify that authentication state is maintained when app goes to background/foreground
- Confirm that token refresh works properly when app resumes
- Test that no memory leaks occur during normal app usage
- Verify that logout functionality still works correctly

### Checklist before requesting a review

[x] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation

### Additional Information

<!-- Add any other relevant information that the reviewer should know. This might include:
    *   Screenshots or videos demonstrating the changes
    *   Links to external resources or documentation
-->

**Technical Details:**
- The `OpenSenseMapBloc` already had a `didChangeAppLifecycleState` method with proper authentication validation logic, but it was never called because the observer wasn't registered
- The fix is minimal and focused, only adding the missing observer registration and improving resource cleanup
- No changes to the authentication logic itself were needed - the existing token refresh and validation code works correctly when called

**Impact:**
- Fixes a critical user experience issue that was causing users to lose their authentication state during rides
- Improves app reliability when users lock/unlock their phones during recording sessions
- Prevents potential memory leaks through better resource management

> **Note:** To trigger a build of the APK for this pull request, add a comment with `/build-apk`.