### PR TITLE
Hotfix: not logged in status display

### DIFF
--- a/lib/services/opensensemap_service.dart
+++ b/lib/services/opensensemap_service.dart
@@ -203,6 +203,14 @@ class OpenSenseMapService {
 
   Future<Map<String, dynamic>?> getUserData() async {
     final cachedUserData = await _getCachedUserData();
+    
+    // If we have cached data and a valid access token, return cached data immediately
+    if (cachedUserData != null) {
+      final accessToken = await getAccessToken();
+      if (accessToken != null) {
+        return cachedUserData;
+      }
+    }
 
     try {
       final userData = await _makeAuthenticatedRequest<Map<String, dynamic>?>(

--- a/lib/services/opensensemap_service.dart
+++ b/lib/services/opensensemap_service.dart
@@ -53,11 +53,7 @@ class OpenSenseMapService {
     _isPermanentlyDisabled = false;
   }
 
-  bool get isAuthenticated {
-    return _cachedAccessToken != null &&
-        _tokenExpiration != null &&
-        _isTokenValid(_cachedAccessToken!);
-  }
+
 
   DateTime? get tokenExpiration => _tokenExpiration;
 

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -141,8 +141,7 @@ class _SenseBoxSelectionButton extends StatelessWidget {
         final textTheme = Theme.of(context).textTheme;
 
         // Always show the button, but with different styling based on authentication
-        final bool isAuthenticated =
-            osemBloc.isAuthenticated && !osemBloc.isAuthenticating;
+        final bool isAuthenticated = osemBloc.isAuthenticated;
         final bool isAuthenticating = osemBloc.isAuthenticating;
 
         return StreamBuilder<SenseBox?>(
@@ -252,13 +251,10 @@ class _SenseBoxSelectionButton extends StatelessWidget {
                       child: Text(
                         label,
                         style: textTheme.bodyLarge?.copyWith(
-                          color: textColor,
-                          fontWeight: FontWeight.w600,
-                          height:
-                              1.2, // Reduce line spacing for more compact text
-                        ),
-                        maxLines:
-                            3, // Allow more lines for the longer login message
+                            color: textColor,
+                            fontWeight: FontWeight.w600,
+                            height: 1.2),
+                        maxLines: 3,
                       ),
                     ),
                     // Optional description (for error or noBox) - only show when authenticated
@@ -307,16 +303,8 @@ class _FloatingButtons extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   _ConnectButton(bleBloc: bleBloc),
-                  // Only show sensebox selection if authenticated
-                  Consumer<OpenSenseMapBloc>(
-                    builder: (context, osemBloc, child) {
-                      if (osemBloc.isAuthenticated &&
-                          !osemBloc.isAuthenticating) {
-                        return _SenseBoxSelectionButton();
-                      }
-                      return SizedBox.shrink();
-                    },
-                  ),
+                  // Always show sensebox selection button with different styling based on auth state
+                  _SenseBoxSelectionButton(),
                 ],
               );
             } else {
@@ -338,16 +326,8 @@ class _FloatingButtons extends StatelessWidget {
                       ),
                     ],
                   ),
-                  // Only show sensebox selection if authenticated
-                  Consumer<OpenSenseMapBloc>(
-                    builder: (context, osemBloc, child) {
-                      if (osemBloc.isAuthenticated &&
-                          !osemBloc.isAuthenticating) {
-                        return _SenseBoxSelectionButton();
-                      }
-                      return SizedBox.shrink();
-                    },
-                  ),
+                  // Always show sensebox selection button with different styling based on auth state
+                  _SenseBoxSelectionButton(),
                 ],
               );
             }

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -257,8 +257,8 @@ class _SenseBoxSelectionButton extends StatelessWidget {
                         maxLines: 3,
                       ),
                     ),
-                    // Optional description (for error or noBox) - only show when authenticated
-                    if (isAuthenticated)
+                    // Optional description (for error or noBox) - only show when authenticated and not loading
+                    if (isAuthenticated && !isAuthenticating)
                       if (hasError)
                         Padding(
                           padding: const EdgeInsets.only(left: 8.0),


### PR DESCRIPTION
Closes #

Fixes authentication flow issues where refresh-auth endpoint was being called instead of login endpoint, and prevents unnecessary API calls to /me endpoint in settings screen.

### Detailed Changes

- Login process only calls the correct sign-in endpoint
- Settings screen uses cached user data instead of making repeated API calls
- UI elements display appropriate states during loading

### Testing
- /me endpoint either called once after login, or not called at all, if user data is cached
- if user is not logged in, corresponding notice is shown on home page
- if login/registration is in progress, loading state is displayed on home page
- if auth token is incorrect in shared settings, on app start and coming back from background, refresh succeeds

### Checklist before requesting a review

[ ] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation

### Additional Information