### PR TITLE
fix: display failed direct upload tracks correclty

### DIFF
--- a/lib/blocs/track_bloc.dart
+++ b/lib/blocs/track_bloc.dart
@@ -77,7 +77,7 @@ class TrackBloc with ChangeNotifier {
       case TrackStatus.notUploaded:
         return Icons.cloud_upload;
       case TrackStatus.directUploadAuthFailed:
-        return Icons.cloud_off;
+        return Icons.cloud_sync;
     }
   }
 

--- a/lib/services/isar_service/track_service.dart
+++ b/lib/services/isar_service/track_service.dart
@@ -102,7 +102,9 @@ class TrackService {
         // Get all tracks, filter unuploaded ones, then apply pagination
         final allTracks = await isar.trackDatas.where().findAll();
         final unuploadedTracks = allTracks
-            .where((track) => track.uploaded != 1 && track.isDirectUpload != 1)
+            .where((track) =>
+                track.uploaded != 1 &&
+                (track.isDirectUpload != 1 || track.uploadAttemptsCount > 0))
             .toList();
         
         // Sort by ID in descending order (newest first)
@@ -118,7 +120,7 @@ class TrackService {
         // Last track is uploaded or doesn't exist, no need to skip
         final allTracks = await isar.trackDatas.where().findAll();
         final unuploadedTracks = allTracks
-            .where((track) => track.uploaded != 1 && track.isDirectUpload != 1)
+            .where((track) => track.uploaded != 1 && (track.isDirectUpload != 1 || track.uploadAttemptsCount > 0))
             .toList();
         
         // Sort by ID in descending order (newest first)
@@ -132,7 +134,7 @@ class TrackService {
       // No need to skip last track
       final allTracks = await isar.trackDatas.where().findAll();
       final unuploadedTracks = allTracks
-          .where((track) => track.uploaded != 1 && track.isDirectUpload != 1)
+          .where((track) => track.uploaded != 1 && (track.isDirectUpload != 1 || track.uploadAttemptsCount > 0))
           .toList();
       
       // Sort by ID in descending order (newest first)

--- a/test/blocs/track_bloc_test.dart
+++ b/test/blocs/track_bloc_test.dart
@@ -179,7 +179,7 @@ void main() {
 
       expect(statusInfo.status, equals(TrackStatus.directUploadAuthFailed));
       expect(statusInfo.color, equals(testTheme.colorScheme.error));
-      expect(statusInfo.icon, equals(Icons.cloud_off));
+      expect(statusInfo.icon, equals(Icons.cloud_sync));
       expect(statusInfo.text, equals('Direct upload auth failed'));
     });
 


### PR DESCRIPTION
Closes #176 

### Detailed Changes
*   Display direct upload track that couldn't be uploaded due to no authentication in the list of not uploaded tracks
*   Mark icon as red in TrackListItem

### Testing
- start track recording in the direct upload mode without authentication
- stop recording
=>
- track should have red "data exchange" icon
- track should be displayed in the list of not uploaded tracks

### Checklist before requesting a review

[ ] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation

### Additional Information
