### PR TITLE
Fix: sufrace anomaly reporting

### DIFF
--- a/lib/utils/track_utils.dart
+++ b/lib/utils/track_utils.dart
@@ -225,6 +225,11 @@ class UploadDataPreparer {
           continue;
         }
 
+        if (FeatureFlags.hideSurfaceAnomalySensor &&
+            sensorTitle == 'surface_anomaly') {
+          continue;
+        }
+
         // Handle multi-value sensors directly
         if (sensorTitle == 'surface_classification' ||
             sensorTitle == 'finedust' ||

--- a/test/utils/track_utils_atrai_test.dart
+++ b/test/utils/track_utils_atrai_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sensebox_bike/feature_flags.dart';
 import 'package:sensebox_bike/models/geolocation_data.dart';
 import 'package:sensebox_bike/models/sensebox.dart';
 import 'package:sensebox_bike/utils/track_utils.dart';
@@ -51,7 +52,10 @@ void main() {
       expect(result.values.any((e) => e['sensor'] == '5'), isTrue);
     });
 
-    test('handles surface sensors', () {
+    test('handles surface sensors when hideSurfaceAnomalySensor is false', () {
+      FeatureFlags.hideSurfaceAnomalySensor = false;
+      addTearDown(() => FeatureFlags.hideSurfaceAnomalySensor = true);
+
       final sensors = [
         Sensor()..id = '8'..title = 'Surface Asphalt',
         Sensor()..id = '9'..title = 'Surface Sett',
@@ -80,6 +84,39 @@ void main() {
       expect(result.values.any((e) => e['sensor'] == '11'), isTrue);
       expect(result.values.any((e) => e['sensor'] == '12'), isTrue);
       expect(result.values.any((e) => e['sensor'] == '13'), isTrue);
+    });
+
+    test('excludes surface_anomaly when hideSurfaceAnomalySensor flag is enabled', () {
+      FeatureFlags.hideSurfaceAnomalySensor = true;
+
+      final sensors = [
+        Sensor()..id = '8'..title = 'Surface Asphalt',
+        Sensor()..id = '9'..title = 'Surface Sett',
+        Sensor()..id = '10'..title = 'Surface Compacted',
+        Sensor()..id = '11'..title = 'Surface Paving',
+        Sensor()..id = '12'..title = 'Standing',
+        Sensor()..id = '13'..title = 'Surface Anomaly',
+      ];
+      final senseBox = SenseBox(sensors: sensors);
+      final preparer = UploadDataPreparer(senseBox: senseBox);
+      final gpsBuffer = [GeolocationData()
+        ..latitude = 10.0
+        ..longitude = 20.0
+        ..timestamp = DateTime.utc(2024, 1, 1, 12, 0, 0)];
+      final groupedData = {
+        gpsBuffer[0]: {
+          'surface_classification': [10.0, 15.0, 20.0, 25.0, 30.0],
+          'surface_anomaly': [35.0],
+        },
+      };
+      final result = preparer.prepareDataFromGroupedData(groupedData, gpsBuffer);
+      expect(result.length, 5,
+          reason: 'surface_anomaly should be excluded from the upload payload');
+      expect(result.values.any((e) => e['sensor'] == '13'), isFalse,
+          reason: 'Surface Anomaly sensor should not be reported');
+      // Surface classification sensors should still be present
+      expect(result.values.any((e) => e['sensor'] == '8'), isTrue);
+      expect(result.values.any((e) => e['sensor'] == '12'), isTrue);
     });
 
     test('handles overtaking sensor', () {

--- a/test/utils/track_utils_atrai_test.dart
+++ b/test/utils/track_utils_atrai_test.dart
@@ -6,6 +6,8 @@ import 'package:sensebox_bike/utils/track_utils.dart';
 
 void main() {
   group('UploadDataPreparer ATRAI', () {
+    setUp(() => FeatureFlags.hideSurfaceAnomalySensor = true);
+
         test('handles distance sensor', () {
           final sensors = [
             Sensor()..id = '7'..title = 'Overtaking Distance',
@@ -54,7 +56,6 @@ void main() {
 
     test('handles surface sensors when hideSurfaceAnomalySensor is false', () {
       FeatureFlags.hideSurfaceAnomalySensor = false;
-      addTearDown(() => FeatureFlags.hideSurfaceAnomalySensor = true);
 
       final sensors = [
         Sensor()..id = '8'..title = 'Surface Asphalt',
@@ -86,8 +87,9 @@ void main() {
       expect(result.values.any((e) => e['sensor'] == '13'), isTrue);
     });
 
-    test('excludes surface_anomaly when hideSurfaceAnomalySensor flag is enabled', () {
-      FeatureFlags.hideSurfaceAnomalySensor = true;
+    test(
+        'excludes surface_anomaly when hideSurfaceAnomalySensor flag is enabled',
+        () {
 
       final sensors = [
         Sensor()..id = '8'..title = 'Surface Asphalt',

--- a/test/utils/track_utils_lauds26_test.dart
+++ b/test/utils/track_utils_lauds26_test.dart
@@ -6,6 +6,8 @@ import 'package:sensebox_bike/utils/track_utils.dart';
 
 void main() {
   group('UploadDataPreparer LAUDS 26', () {
+    setUp(() => FeatureFlags.hideSurfaceAnomalySensor = true);
+
         test('handles distance sensors', () {
           final sensors = [
             Sensor()..id = '7'..title = 'Distance Left',
@@ -60,7 +62,6 @@ void main() {
 
     test('handles surface sensors when hideSurfaceAnomalySensor is false', () {
       FeatureFlags.hideSurfaceAnomalySensor = false;
-      addTearDown(() => FeatureFlags.hideSurfaceAnomalySensor = true);
 
       final sensors = [
         Sensor()..id = '9'..title = 'Surface Asphalt',
@@ -93,7 +94,6 @@ void main() {
     });
 
     test('excludes surface_anomaly when hideSurfaceAnomalySensor flag is enabled', () {
-      FeatureFlags.hideSurfaceAnomalySensor = true;
 
       final sensors = [
         Sensor()..id = '9'..title = 'Surface Asphalt',

--- a/test/utils/track_utils_lauds26_test.dart
+++ b/test/utils/track_utils_lauds26_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sensebox_bike/feature_flags.dart';
 import 'package:sensebox_bike/models/geolocation_data.dart';
 import 'package:sensebox_bike/models/sensebox.dart';
 import 'package:sensebox_bike/utils/track_utils.dart';
@@ -57,7 +58,10 @@ void main() {
       expect(result.values.any((e) => e['sensor'] == '5'), isTrue);
     });
 
-    test('handles surface sensors', () {
+    test('handles surface sensors when hideSurfaceAnomalySensor is false', () {
+      FeatureFlags.hideSurfaceAnomalySensor = false;
+      addTearDown(() => FeatureFlags.hideSurfaceAnomalySensor = true);
+
       final sensors = [
         Sensor()..id = '9'..title = 'Surface Asphalt',
         Sensor()..id = '10'..title = 'Surface Sett',
@@ -86,6 +90,39 @@ void main() {
       expect(result.values.any((e) => e['sensor'] == '12'), isTrue);
       expect(result.values.any((e) => e['sensor'] == '13'), isTrue);
       expect(result.values.any((e) => e['sensor'] == '14'), isTrue);
+    });
+
+    test('excludes surface_anomaly when hideSurfaceAnomalySensor flag is enabled', () {
+      FeatureFlags.hideSurfaceAnomalySensor = true;
+
+      final sensors = [
+        Sensor()..id = '9'..title = 'Surface Asphalt',
+        Sensor()..id = '10'..title = 'Surface Sett',
+        Sensor()..id = '11'..title = 'Surface Compacted',
+        Sensor()..id = '12'..title = 'Surface Paving',
+        Sensor()..id = '13'..title = 'Standing',
+        Sensor()..id = '14'..title = 'Surface Anomaly',
+      ];
+      final senseBox = SenseBox(sensors: sensors);
+      final preparer = UploadDataPreparer(senseBox: senseBox);
+      final gpsBuffer = [GeolocationData()
+        ..latitude = 10.0
+        ..longitude = 20.0
+        ..timestamp = DateTime.utc(2024, 1, 1, 12, 0, 0)];
+      final groupedData = {
+        gpsBuffer[0]: {
+          'surface_classification': [10.0, 15.0, 20.0, 25.0, 30.0],
+          'surface_anomaly': [35.0],
+        },
+      };
+      final result = preparer.prepareDataFromGroupedData(groupedData, gpsBuffer);
+      expect(result.length, 5,
+          reason: 'surface_anomaly should be excluded from the upload payload');
+      expect(result.values.any((e) => e['sensor'] == '14'), isFalse,
+          reason: 'Surface Anomaly sensor should not be reported');
+      // Surface classification sensors should still be present
+      expect(result.values.any((e) => e['sensor'] == '9'), isTrue);
+      expect(result.values.any((e) => e['sensor'] == '13'), isTrue);
     });
 
     test('handles overtaking sensor', () {


### PR DESCRIPTION
Closes #240 

FeatureFlags.hideSurfaceAnomalySensor was only applied to UI components (sensor widgets and display tiles), but had no effect on the data upload path. As a result, surface anomaly measurements were still being included in the OpenSenseMap upload payload even when the flag was set to true.

### Detailed Changes
- track_utils.dart: Added a guard in prepareDataFromGroupedData to skip surface_anomaly entries when FeatureFlags.hideSurfaceAnomalySensor is true, consistent with how the flag is applied in the UI layer.
- Updated existing 'handles surface sensors' tests in the ATRAI and LAUDS26 suites to explicitly set the flag to false, reflecting the expected behaviour when the feature is enabled and added corresponding tests

### Testing
surface anomaly data should not be uploaded to osem

### Checklist before requesting a review

[x] I have performed a self-review of my code
[x] I have added or updated tests
[ ] I have added or updated relevant documentation
