### PR TITLE
fix: exception when navigating to login page

### DIFF
--- a/lib/ui/widgets/common/upload_progress_modal.dart
+++ b/lib/ui/widgets/common/upload_progress_modal.dart
@@ -59,7 +59,7 @@ class _UploadProgressModalState extends State<UploadProgressModal> {
   @override
   void dispose() {
     _progressSubscription.cancel();
-    UploadProgressOverlay.hide();
+    UploadProgressOverlay._resetState();
     super.dispose();
   }
 
@@ -304,6 +304,13 @@ class UploadProgressOverlay {
         _lastContext = null;
       }
     }
+  }
+
+  /// Resets overlay state without navigating. Safe to call from dispose(),
+  /// where the widget tree is locked and Navigator.pop() is forbidden.
+  static void _resetState() {
+    _isShown = false;
+    _lastContext = null;
   }
 
   /// Whether the modal is currently shown


### PR DESCRIPTION
Closes #

I get the following error message at some point after successful login

```
I/flutter (30902): setState() or markNeedsBuild() called when widget tree was locked.
I/flutter (30902): This Overlay widget cannot be marked as needing to build because the framework is locked.
I/flutter (30902): The widget on which setState() or markNeedsBuild() was called was:
I/flutter (30902):   Overlay-[LabeledGlobalKey<OverlayState>[#f0463](https://github.com/reedu-reengineering-education/sensebox-bike-flutter/pull/242#f0463)]
I/flutter (30902): #0      Element.markNeedsBuild.<anonymous closure> (package:flutter/src/widgets/framework.dart:5378:9)
I/flutter (30902): #1      Element.markNeedsBuild (package:flutter/src/widgets/framework.dart:5388:6)
I/flutter (30902): #2      State.setState (package:flutter/src/widgets/framework.dart:1219:15)
I/flutter (30902): #3      OverlayState._didChangeEntryOpacity (package:flutter/src/widgets/overlay.dart:856:5)
I/flutter (30902): #4      OverlayEntry.opaque= (package:flutter/src/widgets/overlay.dart:144:15)
I/flutter (30902): #5      TransitionRoute._handleStatusChanged (package:flutter/src/widgets/routes.dart:304:32)
I/flutter (30902): #6      AnimationLocalStatusListenersMixin.notifyStatusListeners (package:flutter/src/animation/listener_helpers.dart:242:19)
I/flutter (30902): #7      AnimationController._checkStatusChanged (package:flutter/src/animation/animation_controller.dart:941:7)
I/flutter (30902): #8      AnimationController._startSimulation (package:flutter/src/animation/animation_controller.dart:874:5)
I/flutter (30902): #9      AnimationController._animateToInternal (package:flutter/src/animation/animation_controller.dart:687:12)
I/flutter (30902): #10     AnimationController.reverse (package:flutter/src/animation/animation_controller.dart:521:12)
I/flutter (30902): #11     TransitionRoute.didPop (package:flutter/src/widgets/routes.dart:386:20)
I/flutter (30902): #12     LocalHistoryRoute.didPop (package:flutter/src/widgets/routes.dart:940:18)
I/flutter (30902): #13     MaterialRouteTransitionMixin.didPop (package:flutter/src/material/page.dart:132:18)
I/flutter (30902): #14     _RouteEntry.handlePop (package:flutter/src/widgets/navigator.dart:3304:16)
I/flutter (30902): #15     NavigatorState._flushHistoryUpdates (package:flutter/src/widgets/navigator.dart:4453:22)
I/flutter (30902): #16     NavigatorState.pop (package:flutter/src/widgets/navigator.dart:5594:7)
I/flutter (30902): #17     UploadProgressOverlay.hide (package:sensebox_bike/ui/widgets/common/upload_progress_modal.dart:302:21)
I/flutter (30902): #18     _UploadProgressModalState.dispose (package:sensebox_bike/ui/widgets/common/upload_progress_modal.dart:62:27)
I/flutter (30902): #19     StatefulElement.unmount (package:flutter/src/widgets/framework.dart:6033:11)
I/flutter (30902): #20     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2117:13)
I/flutter (30902): #21     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #22     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #23     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #24     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #25     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #26     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #27     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #28     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #29     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #30     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #31     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #32     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #33     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #34     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #35     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #36     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #37     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #38     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #39     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #40     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #41     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #42     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #43     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #44     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #45     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #46     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #47     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #48     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #49     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #50     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #51     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #52     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #53     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #54     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #55     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #56     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #57     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #58     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #59     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #60     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #61     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #62     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #63     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #64     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #65     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #66     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #67     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #68     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #69     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #70     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #71     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #72     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #73     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #74     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #75     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #76     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #77     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #78     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #79     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #80     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #81     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #82     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #83     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #84     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #85     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #86     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #87     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #88     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #89     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #90     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #91     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #92     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #93     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #94     ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #95     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #96     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #97     SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #98     _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #99     _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #100    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #101    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #102    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #103    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #104    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #105    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #106    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #107    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #108    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #109    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #110    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #111    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #112    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #113    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #114    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #115    SingleChildRenderObjectElement.visitChildren (package:flutter/src/widgets/framework.dart:7104:14)
I/flutter (30902): #116    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #117    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #118    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #119    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #120    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #121    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #122    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #123    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #124    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #125    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
D/Sentry  (30902): Serializing object: {
D/Sentry  (30902):      "id": "92849dfc-843e-4be7-bd8d-41ab5294c656"
D/Sentry  (30902): }
W/Sentry  (30902): Failed to delete the current session file.
D/Sentry  (30902): Adding Envelope to offline storage: /data/user/0/de.reedu.senseboxbike/cache/sentry/5ff0d7c47172e610256e746f68c584b13e9959e8/b8520133-17e0-40e1-aee6-78b08a53b6d2.envelope
D/Sentry  (30902): Serializing object: {
D/Sentry  (30902):      "sid": "fca14ce3-0cba-4937-ad05-6139a3d61d25",
D/Sentry  (30902):      "did": "92849dfc-843e-4be7-bd8d-41ab5294c656",
D/Sentry  (30902):      "started": "2026-04-02T10:19:51.476Z",
D/Sentry  (30902):      "status": "ok",
D/Sentry  (30902):      "seq": 1775126136709,
D/Sentry  (30902):      "errors": 4,
D/Sentry  (30902):      "timestamp": "2026-04-02T10:35:36.709Z",
D/Sentry  (30902):      "attrs": {
D/Sentry  (30902):              "release": "[de.reedu.senseboxbike@3.3.9](mailto:de.reedu.senseboxbike@3.3.9)+339",
D/Sentry  (30902):              "environment": "debug"
D/Sentry  (30902):      }
D/Sentry  (30902): }
D/Sentry  (30902): Attaching client report to envelope.
D/Sentry  (30902): Serializing object: {
D/Sentry  (30902):      "timestamp": "2026-04-02T10:35:36.715Z",
D/Sentry  (30902):      "discarded_events": [
D/Sentry  (30902):              {
D/Sentry  (30902):                      "reason": "network_error",
D/Sentry  (30902):                      "category": "session",
D/Sentry  (30902):                      "quantity": 2
D/Sentry  (30902):              },
D/Sentry  (30902):              {
D/Sentry  (30902):                      "reason": "network_error",
D/Sentry  (30902):                      "category": "error",
D/Sentry  (30902):                      "quantity": 2
D/Sentry  (30902):              }
D/Sentry  (30902):      ]
D/Sentry  (30902): }
D/Sentry  (30902): Envelope sent successfully.
D/Sentry  (30902): Discarding envelope from cache: /data/user/0/de.reedu.senseboxbike/cache/sentry/5ff0d7c47172e610256e746f68c584b13e9959e8/b8520133-17e0-40e1-aee6-78b08a53b6d2.envelope
D/Sentry  (30902): Envelope flushed
I/flutter (30902): #126    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #127    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #128    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #129    _InactiveElements._unmount.<anonymous closure> (package:flutter/src/widgets/framework.dart:2115:7)
I/flutter (30902): #130    ComponentElement.visitChildren (package:flutter/src/widgets/framework.dart:5874:14)
I/flutter (30902): #131    _InactiveElements._unmount (package:flutter/src/widgets/framework.dart:2113:13)
I/flutter (30902): #132    ListIterable.forEach (dart:_internal/iterable.dart:49:13)
I/flutter (30902): #133    _InactiveElements._unmountAll (package:flutter/src/widgets/framework.dart:2126:25)
I/flutter (30902): #134    BuildOwner.lockState (package:flutter/src/widgets/framework.dart:3020:15)
I/flutter (30902): #135    BuildOwner.finalizeTree (package:flutter/src/widgets/framework.dart:3344:7)
I/flutter (30902): #136    WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:1269:19)
I/flutter (30902): #137    RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:495:5)
I/flutter (30902): #138    SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1434:15)
I/flutter (30902): #139    SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1347:9)
I/flutter (30902): #140    SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1200:5)
I/flutter (30902): #141    _invoke (dart:ui/hooks.dart:356:13)
I/flutter (30902): #142    PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:444:5)
I/flutter (30902): #143    _drawFrame (dart:ui/hooks.dart:328:31)
I/flutter (30902): [2026-04-02T12:35:36.949461] [BatchUploadService] [INFO] [Service disposal] BatchUploadService disposed
```

### Detailed Changes
<!-- List the specific changes made in this pull request. Be clear and concise. -->
*   Change 1
*   Change 2
*   ...

### Testing
<!-- Describe the testing strategy applied to verify the changes. Include steps to reproduce the changes and validate the solution. -->

### Checklist before requesting a review

[ ] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation

