### PR TITLE
Fix: preserve BLE GPS speed in CSV export for classic box and add tests

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -75,4 +75,7 @@ const List<String> sensorOrder = [
   'gps_latitude',
   'gps_longitude',
   'gps_speed',
+  'sensor_gps_latitude',
+  'sensor_gps_longitude',
+  'sensor_gps_speed',
 ];

--- a/lib/sensors/gps_sensor.dart
+++ b/lib/sensors/gps_sensor.dart
@@ -37,7 +37,7 @@ class GPSSensor extends Sensor {
       IsarService isarService)
       : super(
             sensorCharacteristicUuid,
-            "gps",
+            "sensor_gps",
             ['latitude', 'longitude', 'speed'],
             bleBloc,
             geolocationBloc,

--- a/lib/utils/isar_utils.dart
+++ b/lib/utils/isar_utils.dart
@@ -47,9 +47,16 @@ Set<List<String?>> collectSensorTitles(Map<int, List<SensorData>> sensorDataByGe
   const separator = '%%';
   final sensorTitlesSet = <String>{};
   for (var sensorData in sensorDataByGeolocation.values) {
+    final seenKeys = <String>{};
     for (var sensor in sensorData) {
-      sensorTitlesSet
-          .add('${sensor.title}$separator${sensor.attribute ?? ""}');
+      final key = '${sensor.title}$separator${sensor.attribute ?? ""}';
+      if (seenKeys.contains(key)) {
+        // Duplicate within this geolocation: add as sensor_<title> to avoid overwrite
+        sensorTitlesSet.add('sensor_${sensor.title}$separator${sensor.attribute ?? ""}');
+      } else {
+        seenKeys.add(key);
+        sensorTitlesSet.add(key);
+      }
     }
   }
   return sensorTitlesSet.map((str) {
@@ -100,8 +107,13 @@ Map<String, double?> organizeSensorData(List<SensorData> sensorDataList,{String 
   final sensorMap = <String, double?>{};
 
   for (var sensorData in sensorDataList) {
-    sensorMap['${sensorData.title}$separator${sensorData.attribute}'] =
-        sensorData.value;
+    final key = '${sensorData.title}$separator${sensorData.attribute}';
+    if (sensorMap.containsKey(key)) {
+      // Duplicate key: store under sensor_<title> to preserve both values
+      sensorMap['sensor_${sensorData.title}$separator${sensorData.attribute}'] = sensorData.value;
+    } else {
+      sensorMap[key] = sensorData.value;
+    }
   }
 
   return sensorMap;

--- a/lib/utils/isar_utils.dart
+++ b/lib/utils/isar_utils.dart
@@ -130,25 +130,34 @@ List<List<String>> buildCsvRows(
   List<List<String?>> sensorTitles,
 ) {
   const separator = '%%';
-  return geolocationDataList.map((geoData) {
-    final sensorData = sensorDataByGeolocation[geoData.id] ?? [];
-    if (sensorData.isEmpty) return null;
-    final sensorMap = organizeSensorData(sensorData, separator: separator);
-    final values = sensorTitles.map((title) => sensorMap['${title[0]}$separator${title[1]}']).toList();
-    
+  return geolocationDataList
+      .map((geoData) {
+        final sensorData = sensorDataByGeolocation[geoData.id] ?? [];
+        if (sensorData.isEmpty) return null;
+        final sensorMap = organizeSensorData(sensorData, separator: separator);
+        final values = sensorTitles
+            .map((title) => MapEntry(
+                title[0], sensorMap['${title[0]}$separator${title[1]}']))
+            .toList();
+
         // Format timestamp as UTC ISO8601 string
         final timestampUtc = geoData.timestamp.isUtc
             ? geoData.timestamp
             : geoData.timestamp.toUtc();
         final timestampString = timestampUtc.toIso8601String();
-    
-    return [
+
+        return [
           timestampString,
-      geoData.latitude.toString(),
-      geoData.longitude.toString(),
-          ...values.map((value) =>
-              value?.toStringAsFixed(2) ??
-              ''), // format value to 2 decimal places
-    ];
-  }).whereType<List<String>>().toList();
+          geoData.latitude.toString(),
+          geoData.longitude.toString(),
+          ...values.map((entry) {
+            final isGps = entry.key?.toLowerCase() == 'sensor_gps';
+            return isGps
+                ? (entry.value?.toStringAsFixed(5) ?? '')
+                : (entry.value?.toStringAsFixed(2) ?? '');
+          }),
+        ];
+      })
+      .whereType<List<String>>()
+      .toList();
 }

--- a/lib/utils/isar_utils.dart
+++ b/lib/utils/isar_utils.dart
@@ -106,7 +106,12 @@ List<String> buildCsvHeaders(List<List<String?>> sensorTitles) {
 Map<String, double?> organizeSensorData(List<SensorData> sensorDataList,{String separator = '%%'}) {
   final sensorMap = <String, double?>{};
 
-  for (var sensorData in sensorDataList) {
+  // Sort by id ascending so that the lower-id entry (saved first, i.e. phone
+  // GPS speed) deterministically stays under <title>%%<attribute> and the
+  // higher-id entry (BLE GPS speed, saved later) goes to sensor_<title>.
+  final sorted = List<SensorData>.from(sensorDataList)..sort((a, b) => a.id.compareTo(b.id));
+
+  for (var sensorData in sorted) {
     final key = '${sensorData.title}$separator${sensorData.attribute}';
     if (sensorMap.containsKey(key)) {
       // Duplicate key: store under sensor_<title> to preserve both values

--- a/lib/utils/sensor_utils.dart
+++ b/lib/utils/sensor_utils.dart
@@ -152,10 +152,13 @@ String? getTitleFromSensorKey(String key, String? attribute) {
     case 'acceleration_z':
       return 'Acceleration Z';
     case 'gps_latitude':
+    case 'sensor_gps_latitude':
       return 'GPS Latitude';
     case 'gps_longitude':
+    case 'sensor_gps_longitude':
       return 'GPS Longitude';
     case 'gps_speed':
+    case 'sensor_gps_speed':
       return 'Speed';
     default:
       debugPrint("Unknown sensor key: $searchKey");
@@ -207,10 +210,13 @@ String? getTranslatedTitleFromSensorKey(
     case 'acceleration_z':
       return AppLocalizations.of(context)!.sensorAccelerationZ;
     case 'gps_latitude':
+    case 'sensor_gps_latitude':
       return AppLocalizations.of(context)!.sensorGPSLat;
     case 'gps_longitude':
+    case 'sensor_gps_longitude':
       return AppLocalizations.of(context)!.sensorGPSLong;
     case 'gps_speed':
+    case 'sensor_gps_speed':
       return AppLocalizations.of(context)!.sensorSpeed;
     default:
       debugPrint("Unknown sensor key: $searchKey");
@@ -233,6 +239,7 @@ IconData getSensorIcon(String sensorType) {
     case 'finedust':
       return Icons.grain;
     case 'gps':
+    case 'sensor_gps':
       return Icons.gps_off;
     case 'overtaking':
       return Icons.directions_car;
@@ -258,6 +265,7 @@ Color getSensorColor(String sensorType) {
     case 'finedust':
       return Colors.blueGrey;
     case 'gps':
+    case 'sensor_gps':
       return Colors.blue;
     case 'overtaking':
       return Colors.teal;

--- a/lib/utils/track_utils.dart
+++ b/lib/utils/track_utils.dart
@@ -221,7 +221,7 @@ class UploadDataPreparer {
         final String sensorTitle = sensorEntry.key;
         final List<double> aggregatedValues = sensorEntry.value;
 
-        if (sensorTitle == "gps") {
+        if (sensorTitle == "gps" || sensorTitle == "sensor_gps") {
           continue;
         }
 

--- a/test/utils/isar_utils_test.dart
+++ b/test/utils/isar_utils_test.dart
@@ -73,6 +73,25 @@ void main() {
         'sensor_gps%%speed': 2.5,
       });
     });
+
+    test('is deterministic regardless of input order — lower id always wins primary key', () {
+      final lower = SensorData()
+        ..id = 10
+        ..title = 'gps'
+        ..attribute = 'speed'
+        ..value = 1.5;
+      final higher = SensorData()
+        ..id = 11
+        ..title = 'gps'
+        ..attribute = 'speed'
+        ..value = 2.5;
+      // Pass in reverse order to prove sorting is applied
+      final result = organizeSensorData([higher, lower]);
+      expect(result, {
+        'gps%%speed': 1.5,       // lower id → primary column
+        'sensor_gps%%speed': 2.5, // higher id → sensor_ column
+      });
+    });
   });
 
   group('collectSensorTitles', () {

--- a/test/utils/isar_utils_test.dart
+++ b/test/utils/isar_utils_test.dart
@@ -55,6 +55,24 @@ void main() {
     test('returns empty map for empty list', () {
       expect(organizeSensorData([]), {});
     });
+
+    test('stores duplicate key under sensor_ prefix instead of overwriting', () {
+      final first = SensorData()
+        ..id = 10
+        ..title = 'gps'
+        ..attribute = 'speed'
+        ..value = 1.5;
+      final second = SensorData()
+        ..id = 11
+        ..title = 'gps'
+        ..attribute = 'speed'
+        ..value = 2.5;
+      final result = organizeSensorData([first, second]);
+      expect(result, {
+        'gps%%speed': 1.5,
+        'sensor_gps%%speed': 2.5,
+      });
+    });
   });
 
   group('collectSensorTitles', () {
@@ -77,6 +95,27 @@ void main() {
 
     test('returns empty set for empty map', () {
       expect(collectSensorTitles({}), <List<String?>>{});
+    });
+
+    test('adds sensor_ prefixed entry when a geolocation has duplicate (title, attribute)', () {
+      final gpsSpeed1 = SensorData()
+        ..id = 10
+        ..title = 'gps'
+        ..attribute = 'speed'
+        ..value = 1.5;
+      final gpsSpeed2 = SensorData()
+        ..id = 11
+        ..title = 'gps'
+        ..attribute = 'speed'
+        ..value = 2.5;
+      final Map<int, List<SensorData>> sensorDataByGeolocation = {
+        1: [gpsSpeed1, gpsSpeed2],
+      };
+      final result = collectSensorTitles(sensorDataByGeolocation);
+      expect(result, {
+        ['gps', 'speed'],
+        ['sensor_gps', 'speed'],
+      });
     });
   });
 


### PR DESCRIPTION
The classic box sends GPS speed via BLE (sensor title "gps"), which was stored in the DB with the same key as phone GPS speed, causing the phone speed to be silently overwritten during CSV export.

### Detailed Changes
- Rename BLE GPS sensor title from "gps" to "sensor_gps" so new recordings store BLE GPS data under distinct keys (sensor_gps_*)
- Fix CSV export (organizeSensorData, collectSensorTitles) to detect duplicate (title, attribute) rows per geolocation and store the second value under a sensor_<title> column instead of overwriting, preserving both values for existing tracks in the DB
- Skip "sensor_gps" in OpenSenseMap upload (same behavior as "gps")
- Add sensor_gps_* to sensorOrder and sensor utility lookups
- Add tests for duplicate-key handling in isar_utils

! currently when data is uploaded to osem, no gps sensor data is uploaded

### Testing
Can you please verify that:
- both gps sensor values are displayed on both home and track overview pages
- data export
    - in csv format both existing and new tracks should have new rows for lat, long and speed with "sensor_" prefix
    - data export in osem format should just have duplicate lines for gps data.
    


### Checklist before requesting a review

[x] I have performed a self-review of my code
[x] I have added or updated tests
[ ] I have added or updated relevant documentation