### PR TITLE
Split/ble refactor

### DIFF
--- a/lib/blocs/ble_bloc.dart
+++ b/lib/blocs/ble_bloc.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
-import 'dart:typed_data';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:sensebox_bike/blocs/settings_bloc.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
@@ -16,7 +15,7 @@ const configurableReconnectionDelay = Duration(seconds: 1);
 const _delayAfterDiscoverServices = Duration(milliseconds: 400);
 const _delayBetweenCharacteristicSubscriptions = Duration(milliseconds: 150);
 
-class BleBloc with ChangeNotifier {
+class BleBloc {
   final SettingsBloc settingsBloc;
 
   final ValueNotifier<bool> isBluetoothEnabledNotifier = ValueNotifier(false);
@@ -48,7 +47,6 @@ class BleBloc with ChangeNotifier {
   StreamSubscription<BluetoothAdapterState>? _adapterStateSubscription;
   StreamSubscription<List<ScanResult>>? _scanResultsSubscription;
   StreamSubscription<bool>? _isScanningSubscription;
-  StreamSubscription<List<ScanResult>>? _connectToIdScanSubscription;
   StreamSubscription<BluetoothConnectionState>? _reconnectionListener;
 
   final Map<String, StreamController<List<double>>> _characteristicStreams = {};
@@ -86,7 +84,6 @@ class BleBloc with ChangeNotifier {
   void updateBluetoothStatus(bool isEnabled) {
     if (isBluetoothEnabledNotifier.value != isEnabled) {
       isBluetoothEnabledNotifier.value = isEnabled;
-      notifyListeners();
     }
   }
 
@@ -136,8 +133,7 @@ class BleBloc with ChangeNotifier {
         devicesList.add(result.device);
       }
     }
-    _devicesListController.add(devicesList);
-    notifyListeners();
+    _devicesListController.add(List.from(devicesList));
   }
 
   void disconnectDevice() {
@@ -150,38 +146,50 @@ class BleBloc with ChangeNotifier {
     _reconnectionListener = null;
     resetConnectionError();
     _resetReconnectionState();
-    notifyListeners();
   }
 
-  Future<void> connectToId(String id, BuildContext context) async {
+  Future<BleConnectionResult?> connectToId(String id) async {
     resetConnectionError();
-    await _connectToIdScanSubscription?.cancel();
+    await stopScanning();
 
-    await FlutterBluePlus.startScan(withNames: [id]);
-    _connectToIdScanSubscription =
-        FlutterBluePlus.scanResults.listen((results) async {
-      for (final result in results) {
-        if (result.device.advName.toString() != id) {
+    try {
+      await FlutterBluePlus.startScan(
+        withNames: [id],
+        timeout: deviceConnectTimeout,
+      );
+
+      await for (final results
+          in FlutterBluePlus.scanResults.timeout(deviceConnectTimeout)) {
+        final device = _findScannedDevice(results, id);
+        if (device == null) {
           continue;
         }
 
-        await _connectToIdScanSubscription?.cancel();
-        _connectToIdScanSubscription = null;
         await stopScanning();
-        await connectToDevice(result.device, context);
-        break;
+        return connectToDevice(device);
       }
-    });
+    } on TimeoutException {
+      return null;
+    } finally {
+      await stopScanning();
+    }
+
+    return null;
   }
 
-  Future<BleConnectionResult> connectToDevice(
-    BluetoothDevice device,
-    BuildContext context,
-  ) async {
+  BluetoothDevice? _findScannedDevice(List<ScanResult> results, String id) {
+    for (final result in results) {
+      if (result.device.advName.toString() == id) {
+        return result.device;
+      }
+    }
+    return null;
+  }
+
+  Future<BleConnectionResult> connectToDevice(BluetoothDevice device) async {
     try {
       resetConnectionError();
       isConnectingNotifier.value = true;
-      notifyListeners();
 
       if (isScanningNotifier.value) {
         await stopScanning();
@@ -200,7 +208,7 @@ class BleBloc with ChangeNotifier {
       final result = await _attemptSingleConnection(device);
 
       if (result.success) {
-        _completeConnection(device, context);
+        _completeConnection(device);
       } else {
         await _disconnectDeviceSafe(device);
         _clearSelectedDevice();
@@ -219,12 +227,11 @@ class BleBloc with ChangeNotifier {
     } finally {
       isConnectingNotifier.value = false;
       _isInRetryMode = false;
-      notifyListeners();
     }
   }
 
-  void _completeConnection(BluetoothDevice device, BuildContext context) {
-    _handleDeviceReconnection(device, context);
+  void _completeConnection(BluetoothDevice device) {
+    _handleDeviceReconnection(device);
     selectedDevice = device;
     selectedDeviceNotifier.value = device;
     _isConnected = true;
@@ -233,7 +240,6 @@ class BleBloc with ChangeNotifier {
 
   Future<BleConnectionResult> _reconnectWithRetries(
     BluetoothDevice device,
-    BuildContext context,
   ) async {
     _isInRetryMode = true;
     BleConnectionResult? lastResult;
@@ -271,7 +277,7 @@ class BleBloc with ChangeNotifier {
     }
 
     _isInRetryMode = false;
-    _handleConnectionError(context: context);
+    _handlePermanentConnectionLoss();
 
     return lastResult ??
         BleConnectionResult.failure(reason: BleConnectionFailureReason.noData);
@@ -407,7 +413,6 @@ class BleBloc with ChangeNotifier {
   void _markConnected() {
     _isConnected = true;
     _userInitiatedDisconnect = false;
-    notifyListeners();
   }
 
   Future<bool> _prepareForRetry(BluetoothDevice device) async {
@@ -450,10 +455,7 @@ class BleBloc with ChangeNotifier {
     return null;
   }
 
-  void _handleDeviceReconnection(
-    BluetoothDevice device,
-    BuildContext context,
-  ) {
+  void _handleDeviceReconnection(BluetoothDevice device) {
     _reconnectionListener?.cancel();
 
     _userInitiatedDisconnect = false;
@@ -470,7 +472,7 @@ class BleBloc with ChangeNotifier {
             isReconnectingNotifier.value = true;
 
             try {
-              _startReconnectionProcess(device, context);
+              _startReconnectionProcess(device);
             } catch (e) {
               _isReconnecting = false;
               isReconnectingNotifier.value = false;
@@ -483,14 +485,11 @@ class BleBloc with ChangeNotifier {
     });
 
     _reconnectionListener?.onError((error) {
-      _handleConnectionError(context: context);
+      _handlePermanentConnectionLoss();
     });
   }
 
-  void _startReconnectionProcess(
-    BluetoothDevice device,
-    BuildContext context,
-  ) async {
+  void _startReconnectionProcess(BluetoothDevice device) async {
     if (_isReconnecting) {
       if (_reconnectionAttempts >= _maxReconnectionAttempts) {
         _isReconnecting = false;
@@ -510,7 +509,7 @@ class BleBloc with ChangeNotifier {
       _hasVibrated = true;
     }
 
-    final result = await _reconnectWithRetries(device, context);
+    final result = await _reconnectWithRetries(device);
 
     if (result.success) {
       _isConnected = true;
@@ -522,17 +521,15 @@ class BleBloc with ChangeNotifier {
       isReconnectingNotifier.value = false;
       _isReconnecting = false;
       _isInRetryMode = false;
-
-      notifyListeners();
     }
 
     if (!result.success &&
         _reconnectionAttempts >= _maxReconnectionAttempts) {
-      _handleConnectionError(context: context);
+      _handlePermanentConnectionLoss();
     }
   }
 
-  void _handleConnectionError({required BuildContext context}) {
+  void _handlePermanentConnectionLoss() {
     _clearSelectedDevice();
     connectionErrorNotifier.value = true;
 
@@ -547,8 +544,6 @@ class BleBloc with ChangeNotifier {
     _hasVibrated = false;
     isReconnectingNotifier.value = false;
     isConnectingNotifier.value = false;
-
-    notifyListeners();
   }
 
   void resetConnectionError() {
@@ -558,7 +553,6 @@ class BleBloc with ChangeNotifier {
     _reconnectionListener = null;
 
     _resetReconnectionState();
-    notifyListeners();
   }
 
   void _resetReconnectionState() {
@@ -622,10 +616,8 @@ class BleBloc with ChangeNotifier {
     return parsedValues;
   }
 
-  @override
   void dispose() {
     _adapterStateSubscription?.cancel();
-    _connectToIdScanSubscription?.cancel();
     _cancelScanSubscriptions();
     _reconnectionListener?.cancel();
     _devicesListController.close();
@@ -638,7 +630,6 @@ class BleBloc with ChangeNotifier {
     availableCharacteristics.dispose();
     characteristicStreamsVersion.dispose();
     connectionErrorNotifier.dispose();
-    super.dispose();
   }
 
   Future<void> requestEnableBluetooth() async {

--- a/lib/blocs/ble_bloc.dart
+++ b/lib/blocs/ble_bloc.dart
@@ -21,8 +21,6 @@ class BleBloc {
 
   final ValueNotifier<bool> isBluetoothEnabledNotifier = ValueNotifier(false);
   final ValueNotifier<bool> isScanningNotifier = ValueNotifier(false);
-  final ValueNotifier<bool> isConnectingNotifier = ValueNotifier(false);
-  final ValueNotifier<bool> isReconnectingNotifier = ValueNotifier(false);
   final ValueNotifier<BleConnectionPhase> connectionPhaseNotifier =
       ValueNotifier(BleConnectionPhase.idle);
   final ValueNotifier<BluetoothDevice?> selectedDeviceNotifier =
@@ -86,7 +84,7 @@ class BleBloc {
   }
 
   Future<void> startScanning() async {
-    if (_hasDeviceConnection()) {
+    if (selectedDeviceNotifier.value != null || isConnected) {
       disconnectDevice();
     }
 
@@ -121,10 +119,6 @@ class BleBloc {
     _isScanningSubscription = null;
   }
 
-  bool _hasDeviceConnection() {
-    return selectedDeviceNotifier.value != null || isConnected;
-  }
-
   void _onScanResults(List<ScanResult> results) {
     final devices = <BluetoothDevice>[];
     for (final result in results) {
@@ -143,7 +137,6 @@ class BleBloc {
     _reconnectionListener?.cancel();
     _reconnectionListener = null;
     resetConnectionError();
-    _resetReconnectionState();
   }
 
   Future<BleConnectionResult?> connectToId(String id) async {
@@ -242,10 +235,7 @@ class BleBloc {
     BleConnectionResult? lastResult;
 
     for (var attempt = 0; attempt < _maxReconnectionAttempts; attempt++) {
-      lastResult = await _attemptSingleConnection(
-        device,
-        updateConnectionState: false,
-      );
+      lastResult = await _attemptSingleConnection(device);
 
       if (lastResult.success) {
         return lastResult;
@@ -273,9 +263,8 @@ class BleBloc {
   }
 
   Future<BleConnectionResult> _attemptSingleConnection(
-    BluetoothDevice device, {
-    bool updateConnectionState = true,
-  }) async {
+    BluetoothDevice device,
+  ) async {
     try {
       if (!device.isConnected) {
         return BleConnectionResult.failure(
@@ -341,10 +330,6 @@ class BleBloc {
         );
       }
 
-      if (updateConnectionState) {
-        _userInitiatedDisconnect = false;
-        _setConnectionPhase(BleConnectionPhase.connected);
-      }
       return BleConnectionResult.fullSuccess();
     } catch (e) {
       return BleConnectionResult.failure(
@@ -405,8 +390,6 @@ class BleBloc {
 
     _connectionPhase = phase;
     connectionPhaseNotifier.value = phase;
-    isConnectingNotifier.value = phase == BleConnectionPhase.connecting;
-    isReconnectingNotifier.value = phase == BleConnectionPhase.reconnecting;
   }
 
   static String _characteristicUuid(BluetoothCharacteristic characteristic) {
@@ -493,8 +476,10 @@ class BleBloc {
     if (result.success) {
       selectedDeviceNotifier.value = device;
       _userInitiatedDisconnect = false;
-      _resetReconnectionCounters();
+      _hasVibrated = false;
       _setConnectionPhase(BleConnectionPhase.connected);
+    } else if (_connectionPhase == BleConnectionPhase.reconnecting) {
+      _setConnectionPhase(BleConnectionPhase.idle);
     }
   }
 
@@ -506,8 +491,7 @@ class BleBloc {
     _reconnectionListener = null;
 
     _clearCharacteristicStreams();
-    _resetReconnectionCounters();
-    isConnectingNotifier.value = false;
+    _hasVibrated = false;
   }
 
   void resetConnectionError() {
@@ -516,21 +500,9 @@ class BleBloc {
     _reconnectionListener?.cancel();
     _reconnectionListener = null;
 
-    _resetReconnectionState();
-  }
-
-  void _resetReconnectionState() {
-    _resetReconnectionCounters();
     if (_connectionPhase == BleConnectionPhase.reconnecting) {
       _setConnectionPhase(BleConnectionPhase.idle);
-    } else {
-      isReconnectingNotifier.value = false;
     }
-  }
-
-  void _resetReconnectionCounters() {
-    _hasVibrated = false;
-    isReconnectingNotifier.value = false;
   }
 
   Future<void> _listenToCharacteristic(
@@ -593,8 +565,6 @@ class BleBloc {
     _clearCharacteristicStreams();
     isBluetoothEnabledNotifier.dispose();
     isScanningNotifier.dispose();
-    isConnectingNotifier.dispose();
-    isReconnectingNotifier.dispose();
     connectionPhaseNotifier.dispose();
     selectedDeviceNotifier.dispose();
     discoveredDevicesNotifier.dispose();

--- a/lib/blocs/ble_bloc.dart
+++ b/lib/blocs/ble_bloc.dart
@@ -1,13 +1,11 @@
 import 'dart:async';
-
 import 'dart:typed_data';
-import 'package:flutter/widgets.dart';
-import 'package:sensebox_bike/blocs/settings_bloc.dart';
-import 'package:sensebox_bike/secrets.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-
+import 'package:sensebox_bike/blocs/settings_bloc.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
+import 'package:sensebox_bike/secrets.dart';
 import 'package:sensebox_bike/services/custom_exceptions.dart';
 import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/utils/sensor_utils.dart';
@@ -33,7 +31,6 @@ class BleBloc with ChangeNotifier {
   final ValueNotifier<bool> connectionErrorNotifier = ValueNotifier(false);
 
   final List<BluetoothDevice> devicesList = [];
-  List<String> failedCharacteristicUuids = [];
   final StreamController<List<BluetoothDevice>> _devicesListController =
       StreamController.broadcast();
   Stream<List<BluetoothDevice>> get devicesListStream =>
@@ -47,11 +44,12 @@ class BleBloc with ChangeNotifier {
   int _reconnectionAttempts = 0;
   bool _hasVibrated = false;
   static const int _maxReconnectionAttempts = 10;
-  
-  StreamSubscription<BluetoothConnectionState>? _reconnectionListener;
 
-  BluetoothService? _pendingSenseBoxService;
-  List<String> _pendingValidUuids = [];
+  StreamSubscription<BluetoothAdapterState>? _adapterStateSubscription;
+  StreamSubscription<List<ScanResult>>? _scanResultsSubscription;
+  StreamSubscription<bool>? _isScanningSubscription;
+  StreamSubscription<List<ScanResult>>? _connectToIdScanSubscription;
+  StreamSubscription<BluetoothConnectionState>? _reconnectionListener;
 
   final Map<String, StreamController<List<double>>> _characteristicStreams = {};
   final Map<String, StreamSubscription<List<int>>>
@@ -72,7 +70,8 @@ class BleBloc with ChangeNotifier {
 
   BleBloc(this.settingsBloc) {
     FlutterBluePlus.setLogLevel(LogLevel.error);
-    FlutterBluePlus.adapterState.listen((state) {
+    _adapterStateSubscription =
+        FlutterBluePlus.adapterState.listen((state) {
       updateBluetoothStatus(state == BluetoothAdapterState.on);
     });
 
@@ -80,8 +79,7 @@ class BleBloc with ChangeNotifier {
   }
 
   Future<void> _initializeBluetoothStatus() async {
-    BluetoothAdapterState currentState =
-        await FlutterBluePlus.adapterState.first;
+    final currentState = await FlutterBluePlus.adapterState.first;
     updateBluetoothStatus(currentState == BluetoothAdapterState.on);
   }
 
@@ -97,6 +95,7 @@ class BleBloc with ChangeNotifier {
       disconnectDevice();
     }
 
+    await _cancelScanSubscriptions();
     isScanningNotifier.value = true;
 
     try {
@@ -106,21 +105,28 @@ class BleBloc with ChangeNotifier {
       throw ScanPermissionDenied();
     }
 
-    FlutterBluePlus.scanResults.listen(_onScanResults);
-    FlutterBluePlus.isScanning.listen((scanning) {
+    _scanResultsSubscription =
+        FlutterBluePlus.scanResults.listen(_onScanResults);
+    _isScanningSubscription = FlutterBluePlus.isScanning.listen((scanning) {
       isScanningNotifier.value = scanning;
     });
   }
 
   Future<void> stopScanning() async {
+    await _cancelScanSubscriptions();
     await FlutterBluePlus.stopScan();
     isScanningNotifier.value = false;
   }
 
+  Future<void> _cancelScanSubscriptions() async {
+    await _scanResultsSubscription?.cancel();
+    _scanResultsSubscription = null;
+    await _isScanningSubscription?.cancel();
+    _isScanningSubscription = null;
+  }
+
   bool _hasDeviceConnection() {
-    return selectedDevice != null ||
-        _isConnected ||
-        _pendingSenseBoxService != null;
+    return selectedDevice != null || _isConnected;
   }
 
   void _onScanResults(List<ScanResult> results) {
@@ -138,45 +144,46 @@ class BleBloc with ChangeNotifier {
     _userInitiatedDisconnect = true;
     _isInRetryMode = false;
     selectedDevice?.disconnect();
-    _isConnected = false;
-    selectedDevice = null;
-    selectedDeviceNotifier.value = null;
+    _clearSelectedDevice();
     availableCharacteristics.value = [];
-    failedCharacteristicUuids = [];
-    _clearPendingConnection();
     _reconnectionListener?.cancel();
     _reconnectionListener = null;
     resetConnectionError();
-
     _resetReconnectionState();
-
     notifyListeners();
   }
 
   Future<void> connectToId(String id, BuildContext context) async {
     resetConnectionError();
-    
+    await _connectToIdScanSubscription?.cancel();
+
     await FlutterBluePlus.startScan(withNames: [id]);
-    FlutterBluePlus.scanResults.listen((results) async {
-      for (ScanResult result in results) {
-        if (result.device.advName.toString() == id) {
-          await connectToDevice(result.device, context);
-          break;
+    _connectToIdScanSubscription =
+        FlutterBluePlus.scanResults.listen((results) async {
+      for (final result in results) {
+        if (result.device.advName.toString() != id) {
+          continue;
         }
+
+        await _connectToIdScanSubscription?.cancel();
+        _connectToIdScanSubscription = null;
+        await stopScanning();
+        await connectToDevice(result.device, context);
+        break;
       }
     });
   }
 
   Future<BleConnectionResult> connectToDevice(
-      BluetoothDevice device, BuildContext context) async {
+    BluetoothDevice device,
+    BuildContext context,
+  ) async {
     try {
       resetConnectionError();
-      _clearPendingConnection();
-
       isConnectingNotifier.value = true;
       notifyListeners();
 
-      if (isScanningNotifier.value == true) {
+      if (isScanningNotifier.value) {
         await stopScanning();
       }
 
@@ -184,30 +191,19 @@ class BleBloc with ChangeNotifier {
         await device.connect(timeout: deviceConnectTimeout);
       } catch (e) {
         await _disconnectDeviceSafe(device);
-        selectedDevice = null;
-        selectedDeviceNotifier.value = null;
-        _isConnected = false;
+        _clearSelectedDevice();
         return BleConnectionResult.failure(
           reason: BleConnectionResult.fromException(e),
         );
       }
 
-      final result = await _runConnectionAttempt(
-        device,
-        autoAcceptPartial: false,
-      );
+      final result = await _attemptSingleConnection(device);
 
       if (result.success) {
         _completeConnection(device, context);
-      } else if (result.needsUserDecision) {
-        _isConnected = false;
-        selectedDevice = null;
-        selectedDeviceNotifier.value = null;
       } else {
         await _disconnectDeviceSafe(device);
-        selectedDevice = null;
-        selectedDeviceNotifier.value = null;
-        _isConnected = false;
+        _clearSelectedDevice();
       }
 
       return result;
@@ -215,9 +211,7 @@ class BleBloc with ChangeNotifier {
       ErrorService.handleError(e, StackTrace.current);
 
       await _disconnectDeviceSafe(device);
-      selectedDevice = null;
-      selectedDeviceNotifier.value = null;
-      _isConnected = false;
+      _clearSelectedDevice();
 
       return BleConnectionResult.failure(
         reason: BleConnectionResult.fromException(e),
@@ -229,72 +223,12 @@ class BleBloc with ChangeNotifier {
     }
   }
 
-  Future<BleConnectionResult> finalizePartialConnection(
-    BluetoothDevice device,
-    BuildContext context,
-  ) async {
-    if (_pendingSenseBoxService == null || _pendingValidUuids.isEmpty) {
-      return BleConnectionResult.failure(
-        reason: BleConnectionFailureReason.bluetoothError,
-      );
-    }
-
-    try {
-      final validUuids = _pendingValidUuids.toSet();
-      final characteristics = _pendingSenseBoxService!.characteristics
-          .where((c) => validUuids.contains(_characteristicUuid(c)))
-          .toList();
-
-      failedCharacteristicUuids = _pendingSenseBoxService!.characteristics
-          .map(_characteristicUuid)
-          .where((uuid) => !validUuids.contains(uuid))
-          .toList();
-
-      final subscribed = await _applyConnection(device, characteristics);
-      if (subscribed.isEmpty) {
-        return BleConnectionResult.failure(
-          reason: BleConnectionFailureReason.noData,
-        );
-      }
-
-      _completeConnection(device, context);
-      _clearPendingConnection();
-
-      return BleConnectionResult.fullSuccess();
-    } catch (e) {
-      await _disconnectDeviceSafe(device);
-      return BleConnectionResult.failure(
-        reason: BleConnectionFailureReason.bluetoothError,
-      );
-    } finally {
-      notifyListeners();
-    }
-  }
-
   void _completeConnection(BluetoothDevice device, BuildContext context) {
     _handleDeviceReconnection(device, context);
     selectedDevice = device;
-    selectedDeviceNotifier.value = selectedDevice;
+    selectedDeviceNotifier.value = device;
     _isConnected = true;
     _userInitiatedDisconnect = false;
-  }
-
-  Future<BleConnectionResult> _runConnectionAttempt(
-    BluetoothDevice device, {
-    bool updateConnectionState = true,
-    bool autoAcceptPartial = false,
-  }) async {
-    try {
-      return await _attemptSingleConnection(
-        device,
-        updateConnectionState: updateConnectionState,
-        autoAcceptPartial: autoAcceptPartial,
-      );
-    } catch (e) {
-      return BleConnectionResult.failure(
-        reason: BleConnectionResult.fromException(e),
-      );
-    }
   }
 
   Future<BleConnectionResult> _reconnectWithRetries(
@@ -311,10 +245,9 @@ class BleBloc with ChangeNotifier {
         _isConnected = false;
       }
 
-      lastResult = await _runConnectionAttempt(
+      lastResult = await _attemptSingleConnection(
         device,
         updateConnectionState: false,
-        autoAcceptPartial: true,
       );
 
       if (lastResult.success) {
@@ -338,7 +271,7 @@ class BleBloc with ChangeNotifier {
     }
 
     _isInRetryMode = false;
-    _handleConnectionError(context: context, isInitialConnection: false);
+    _handleConnectionError(context: context);
 
     return lastResult ??
         BleConnectionResult.failure(reason: BleConnectionFailureReason.noData);
@@ -347,7 +280,6 @@ class BleBloc with ChangeNotifier {
   Future<BleConnectionResult> _attemptSingleConnection(
     BluetoothDevice device, {
     bool updateConnectionState = true,
-    bool autoAcceptPartial = false,
   }) async {
     try {
       if (!device.isConnected) {
@@ -414,11 +346,6 @@ class BleBloc with ChangeNotifier {
         );
       }
 
-      failedCharacteristicUuids = knownCharacteristics
-          .map(_characteristicUuid)
-          .where((uuid) => !subscribed.any((c) => _characteristicUuid(c) == uuid))
-          .toList();
-
       if (updateConnectionState) {
         _markConnected();
       }
@@ -467,9 +394,10 @@ class BleBloc with ChangeNotifier {
     }
   }
 
-  void _clearPendingConnection() {
-    _pendingSenseBoxService = null;
-    _pendingValidUuids = [];
+  void _clearSelectedDevice() {
+    selectedDevice = null;
+    selectedDeviceNotifier.value = null;
+    _isConnected = false;
   }
 
   static String _characteristicUuid(BluetoothCharacteristic characteristic) {
@@ -482,7 +410,6 @@ class BleBloc with ChangeNotifier {
     notifyListeners();
   }
 
-  /// Disconnects and reconnects before the next connection attempt.
   Future<bool> _prepareForRetry(BluetoothDevice device) async {
     try {
       try {
@@ -503,12 +430,12 @@ class BleBloc with ChangeNotifier {
   }
 
   void _clearCharacteristicStreams() {
-    for (var subscription in _characteristicSubscriptions.values) {
+    for (final subscription in _characteristicSubscriptions.values) {
       subscription.cancel();
     }
     _characteristicSubscriptions.clear();
-    
-    for (var controller in _characteristicStreams.values) {
+
+    for (final controller in _characteristicStreams.values) {
       controller.close();
     }
     _characteristicStreams.clear();
@@ -523,11 +450,12 @@ class BleBloc with ChangeNotifier {
     return null;
   }
 
-
-
-  void _handleDeviceReconnection(BluetoothDevice device, BuildContext context) {
+  void _handleDeviceReconnection(
+    BluetoothDevice device,
+    BuildContext context,
+  ) {
     _reconnectionListener?.cancel();
-    
+
     _userInitiatedDisconnect = false;
     _hasVibrated = false;
     _reconnectionAttempts = 0;
@@ -541,11 +469,9 @@ class BleBloc with ChangeNotifier {
             _isConnected = false;
             isReconnectingNotifier.value = true;
 
-            // Start the actual reconnection process
             try {
               _startReconnectionProcess(device, context);
             } catch (e) {
-              // Reset state if reconnection process fails to start
               _isReconnecting = false;
               isReconnectingNotifier.value = false;
             }
@@ -557,7 +483,7 @@ class BleBloc with ChangeNotifier {
     });
 
     _reconnectionListener?.onError((error) {
-      _handleConnectionError(context: context, isInitialConnection: false);
+      _handleConnectionError(context: context);
     });
   }
 
@@ -565,11 +491,7 @@ class BleBloc with ChangeNotifier {
     BluetoothDevice device,
     BuildContext context,
   ) async {
-
-    
-    // Check if reconnection is already in progress
     if (_isReconnecting) {
-      // If we've been trying for too long, reset and start fresh
       if (_reconnectionAttempts >= _maxReconnectionAttempts) {
         _isReconnecting = false;
         _reconnectionAttempts = 0;
@@ -593,7 +515,7 @@ class BleBloc with ChangeNotifier {
     if (result.success) {
       _isConnected = true;
       selectedDevice = device;
-      selectedDeviceNotifier.value = selectedDevice;
+      selectedDeviceNotifier.value = device;
       _userInitiatedDisconnect = false;
       _hasVibrated = false;
       _reconnectionAttempts = 0;
@@ -606,41 +528,25 @@ class BleBloc with ChangeNotifier {
 
     if (!result.success &&
         _reconnectionAttempts >= _maxReconnectionAttempts) {
-      _handleConnectionError(context: context, isInitialConnection: false);
+      _handleConnectionError(context: context);
     }
   }
 
-  void _handleConnectionError(
-      {required BuildContext context, bool isInitialConnection = false}) {
-    if (isInitialConnection) {
-      selectedDeviceNotifier.value = null;
-      _isConnected = false;
-      _userInitiatedDisconnect = false;
-      _resetReconnectionState();
-      isConnectingNotifier.value = false;
-    } else {
-      // Max reconnection attempts reached - handle as permanent connection failure
-      // Reset state and notify connection error
-      selectedDevice = null;
-      selectedDeviceNotifier.value = null;
-      _isConnected = false;
-      connectionErrorNotifier.value = true;
-      
-      // Cancel any ongoing reconnection listener
-      _reconnectionListener?.cancel();
-      _reconnectionListener = null;
+  void _handleConnectionError({required BuildContext context}) {
+    _clearSelectedDevice();
+    connectionErrorNotifier.value = true;
 
-      // Clear characteristic streams
-      _clearCharacteristicStreams();
+    _reconnectionListener?.cancel();
+    _reconnectionListener = null;
 
-      // Reset reconnection state
-      _isReconnecting = false;
-      _isInRetryMode = false;
-      _reconnectionAttempts = 0;
-      _hasVibrated = false;
-      isReconnectingNotifier.value = false;
-      isConnectingNotifier.value = false;
-    }
+    _clearCharacteristicStreams();
+
+    _isReconnecting = false;
+    _isInRetryMode = false;
+    _reconnectionAttempts = 0;
+    _hasVibrated = false;
+    isReconnectingNotifier.value = false;
+    isConnectingNotifier.value = false;
 
     notifyListeners();
   }
@@ -648,17 +554,10 @@ class BleBloc with ChangeNotifier {
   void resetConnectionError() {
     connectionErrorNotifier.value = false;
 
-    // Cancel any ongoing reconnection listener
     _reconnectionListener?.cancel();
     _reconnectionListener = null;
 
-    // Reset reconnection state
-    _isReconnecting = false;
-    _isInRetryMode = false;
-    _reconnectionAttempts = 0;
-    _hasVibrated = false;
-    isReconnectingNotifier.value = false;
-    
+    _resetReconnectionState();
     notifyListeners();
   }
 
@@ -667,15 +566,12 @@ class BleBloc with ChangeNotifier {
     _isInRetryMode = false;
     _reconnectionAttempts = 0;
     _hasVibrated = false;
-
     isReconnectingNotifier.value = false;
-    notifyListeners();
   }
 
-
-
   Future<void> _listenToCharacteristic(
-      BluetoothCharacteristic characteristic) async {
+    BluetoothCharacteristic characteristic,
+  ) async {
     final uuid = _characteristicUuid(characteristic);
 
     await _characteristicSubscriptions[uuid]?.cancel();
@@ -694,15 +590,12 @@ class BleBloc with ChangeNotifier {
     }
     final subscription = characteristic.onValueReceived.listen((value) {
       if (!controller.isClosed) {
-        List<double> parsedData = _parseData(Uint8List.fromList(value));
-
+        final parsedData = _parseData(Uint8List.fromList(value));
         controller.add(parsedData);
       }
     });
     _characteristicSubscriptions[uuid] = subscription;
   }
-
-
 
   bool hasCharacteristicStream(String characteristicUuid) {
     return _characteristicStreams
@@ -718,12 +611,12 @@ class BleBloc with ChangeNotifier {
   }
 
   List<double> _parseData(Uint8List value) {
-    // This method will convert the incoming data to a list of doubles
-    List<double> parsedValues = [];
-    for (int i = 0; i < value.length; i += 4) {
+    final parsedValues = <double>[];
+    for (var i = 0; i < value.length; i += 4) {
       if (i + 4 <= value.length) {
         parsedValues.add(
-            ByteData.sublistView(value, i, i + 4).getFloat32(0, Endian.little));
+          ByteData.sublistView(value, i, i + 4).getFloat32(0, Endian.little),
+        );
       }
     }
     return parsedValues;
@@ -731,6 +624,9 @@ class BleBloc with ChangeNotifier {
 
   @override
   void dispose() {
+    _adapterStateSubscription?.cancel();
+    _connectToIdScanSubscription?.cancel();
+    _cancelScanSubscriptions();
     _reconnectionListener?.cancel();
     _devicesListController.close();
     _clearCharacteristicStreams();

--- a/lib/blocs/ble_bloc.dart
+++ b/lib/blocs/ble_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:sensebox_bike/blocs/settings_bloc.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
 import 'package:sensebox_bike/secrets.dart';
 import 'package:sensebox_bike/services/custom_exceptions.dart';
@@ -22,25 +23,19 @@ class BleBloc {
   final ValueNotifier<bool> isScanningNotifier = ValueNotifier(false);
   final ValueNotifier<bool> isConnectingNotifier = ValueNotifier(false);
   final ValueNotifier<bool> isReconnectingNotifier = ValueNotifier(false);
+  final ValueNotifier<BleConnectionPhase> connectionPhaseNotifier =
+      ValueNotifier(BleConnectionPhase.idle);
   final ValueNotifier<BluetoothDevice?> selectedDeviceNotifier =
       ValueNotifier(null);
+  final ValueNotifier<List<BluetoothDevice>> discoveredDevicesNotifier =
+      ValueNotifier([]);
   final ValueNotifier<List<BluetoothCharacteristic>> availableCharacteristics =
       ValueNotifier([]);
   final ValueNotifier<int> characteristicStreamsVersion = ValueNotifier(0);
   final ValueNotifier<bool> connectionErrorNotifier = ValueNotifier(false);
 
-  final List<BluetoothDevice> devicesList = [];
-  final StreamController<List<BluetoothDevice>> _devicesListController =
-      StreamController.broadcast();
-  Stream<List<BluetoothDevice>> get devicesListStream =>
-      _devicesListController.stream;
-
-  BluetoothDevice? selectedDevice;
-  bool _isConnected = false;
-  bool _isReconnecting = false;
+  BleConnectionPhase _connectionPhase = BleConnectionPhase.idle;
   bool _userInitiatedDisconnect = false;
-  bool _isInRetryMode = false;
-  int _reconnectionAttempts = 0;
   bool _hasVibrated = false;
   static const int _maxReconnectionAttempts = 10;
 
@@ -53,27 +48,30 @@ class BleBloc {
   final Map<String, StreamSubscription<List<int>>>
       _characteristicSubscriptions = {};
 
-  bool get isConnected => _isConnected;
+  bool get isConnected => _connectionPhase == BleConnectionPhase.connected;
 
   bool get isReadyForRecording {
-    final device = selectedDevice;
-    return _isConnected &&
+    final device = selectedDeviceNotifier.value;
+    return _connectionPhase == BleConnectionPhase.connected &&
         device != null &&
         device.isConnected &&
-        !_isReconnecting &&
-        !isConnectingNotifier.value &&
         !connectionErrorNotifier.value &&
         availableCharacteristics.value.isNotEmpty;
   }
 
   BleBloc(this.settingsBloc) {
+    unawaited(_initialize());
+  }
+
+  Future<void> _initialize() async {
+    await FlutterBluePlus.setOptions(restoreState: true);
     FlutterBluePlus.setLogLevel(LogLevel.error);
     _adapterStateSubscription =
         FlutterBluePlus.adapterState.listen((state) {
       updateBluetoothStatus(state == BluetoothAdapterState.on);
     });
 
-    _initializeBluetoothStatus();
+    await _initializeBluetoothStatus();
   }
 
   Future<void> _initializeBluetoothStatus() async {
@@ -93,6 +91,7 @@ class BleBloc {
     }
 
     await _cancelScanSubscriptions();
+    discoveredDevicesNotifier.value = [];
     isScanningNotifier.value = true;
 
     try {
@@ -123,23 +122,22 @@ class BleBloc {
   }
 
   bool _hasDeviceConnection() {
-    return selectedDevice != null || _isConnected;
+    return selectedDeviceNotifier.value != null || isConnected;
   }
 
   void _onScanResults(List<ScanResult> results) {
-    devicesList.clear();
+    final devices = <BluetoothDevice>[];
     for (final result in results) {
       if (result.device.platformName.startsWith('senseBox')) {
-        devicesList.add(result.device);
+        devices.add(result.device);
       }
     }
-    _devicesListController.add(List.from(devicesList));
+    discoveredDevicesNotifier.value = devices;
   }
 
   void disconnectDevice() {
     _userInitiatedDisconnect = true;
-    _isInRetryMode = false;
-    selectedDevice?.disconnect();
+    selectedDeviceNotifier.value?.disconnect();
     _clearSelectedDevice();
     availableCharacteristics.value = [];
     _reconnectionListener?.cancel();
@@ -189,7 +187,7 @@ class BleBloc {
   Future<BleConnectionResult> connectToDevice(BluetoothDevice device) async {
     try {
       resetConnectionError();
-      isConnectingNotifier.value = true;
+      _setConnectionPhase(BleConnectionPhase.connecting);
 
       if (isScanningNotifier.value) {
         await stopScanning();
@@ -225,39 +223,31 @@ class BleBloc {
         reason: BleConnectionResult.fromException(e),
       );
     } finally {
-      isConnectingNotifier.value = false;
-      _isInRetryMode = false;
+      if (_connectionPhase == BleConnectionPhase.connecting) {
+        _setConnectionPhase(BleConnectionPhase.idle);
+      }
     }
   }
 
   void _completeConnection(BluetoothDevice device) {
     _handleDeviceReconnection(device);
-    selectedDevice = device;
     selectedDeviceNotifier.value = device;
-    _isConnected = true;
     _userInitiatedDisconnect = false;
+    _setConnectionPhase(BleConnectionPhase.connected);
   }
 
   Future<BleConnectionResult> _reconnectWithRetries(
     BluetoothDevice device,
   ) async {
-    _isInRetryMode = true;
     BleConnectionResult? lastResult;
 
     for (var attempt = 0; attempt < _maxReconnectionAttempts; attempt++) {
-      _reconnectionAttempts++;
-
-      if (attempt > 0) {
-        _isConnected = false;
-      }
-
       lastResult = await _attemptSingleConnection(
         device,
         updateConnectionState: false,
       );
 
       if (lastResult.success) {
-        _isInRetryMode = false;
         return lastResult;
       }
 
@@ -276,7 +266,6 @@ class BleBloc {
       }
     }
 
-    _isInRetryMode = false;
     _handlePermanentConnectionLoss();
 
     return lastResult ??
@@ -353,7 +342,8 @@ class BleBloc {
       }
 
       if (updateConnectionState) {
-        _markConnected();
+        _userInitiatedDisconnect = false;
+        _setConnectionPhase(BleConnectionPhase.connected);
       }
       return BleConnectionResult.fullSuccess();
     } catch (e) {
@@ -377,11 +367,14 @@ class BleBloc {
         await Future.delayed(_delayBetweenCharacteristicSubscriptions);
       }
 
+      final characteristic = characteristics[i];
       try {
-        await _listenToCharacteristic(characteristics[i]);
-        subscribed.add(characteristics[i]);
-      } catch (e) {
-        // Skip individual characteristics that fail to subscribe.
+        await _listenToCharacteristic(characteristic);
+        subscribed.add(characteristic);
+      } catch (e, stack) {
+        debugPrint(
+          'BLE subscribe failed for ${_characteristicUuid(characteristic)}: $e\n$stack',
+        );
       }
     }
 
@@ -401,18 +394,23 @@ class BleBloc {
   }
 
   void _clearSelectedDevice() {
-    selectedDevice = null;
     selectedDeviceNotifier.value = null;
-    _isConnected = false;
+    _setConnectionPhase(BleConnectionPhase.idle);
+  }
+
+  void _setConnectionPhase(BleConnectionPhase phase) {
+    if (_connectionPhase == phase) {
+      return;
+    }
+
+    _connectionPhase = phase;
+    connectionPhaseNotifier.value = phase;
+    isConnectingNotifier.value = phase == BleConnectionPhase.connecting;
+    isReconnectingNotifier.value = phase == BleConnectionPhase.reconnecting;
   }
 
   static String _characteristicUuid(BluetoothCharacteristic characteristic) {
     return characteristic.uuid.toString().toLowerCase();
-  }
-
-  void _markConnected() {
-    _isConnected = true;
-    _userInitiatedDisconnect = false;
   }
 
   Future<bool> _prepareForRetry(BluetoothDevice device) async {
@@ -460,27 +458,13 @@ class BleBloc {
 
     _userInitiatedDisconnect = false;
     _hasVibrated = false;
-    _reconnectionAttempts = 0;
 
-    _reconnectionListener = device.connectionState.listen((state) async {
-      try {
-        if (state == BluetoothConnectionState.disconnected &&
-            !_userInitiatedDisconnect &&
-            !_isInRetryMode) {
-          if (!_isReconnecting) {
-            _isConnected = false;
-            isReconnectingNotifier.value = true;
-
-            try {
-              _startReconnectionProcess(device);
-            } catch (e) {
-              _isReconnecting = false;
-              isReconnectingNotifier.value = false;
-            }
-          }
-        }
-      } catch (e) {
-        // Don't throw - let the reconnection process handle it
+    _reconnectionListener = device.connectionState.listen((state) {
+      if (state == BluetoothConnectionState.disconnected &&
+          !_userInitiatedDisconnect &&
+          _connectionPhase != BleConnectionPhase.reconnecting &&
+          _connectionPhase != BleConnectionPhase.connecting) {
+        _beginReconnection(device);
       }
     });
 
@@ -489,21 +473,16 @@ class BleBloc {
     });
   }
 
-  void _startReconnectionProcess(BluetoothDevice device) async {
-    if (_isReconnecting) {
-      if (_reconnectionAttempts >= _maxReconnectionAttempts) {
-        _isReconnecting = false;
-        _reconnectionAttempts = 0;
-        _hasVibrated = false;
-        isReconnectingNotifier.value = false;
-      } else {
-        return;
-      }
+  void _beginReconnection(BluetoothDevice device) {
+    if (_connectionPhase == BleConnectionPhase.reconnecting) {
+      return;
     }
 
-    _isReconnecting = true;
-    _isInRetryMode = true;
+    _setConnectionPhase(BleConnectionPhase.reconnecting);
+    unawaited(_runReconnection(device));
+  }
 
+  Future<void> _runReconnection(BluetoothDevice device) async {
     if (!_hasVibrated && settingsBloc.vibrateOnDisconnect) {
       Vibration.vibrate();
       _hasVibrated = true;
@@ -512,20 +491,10 @@ class BleBloc {
     final result = await _reconnectWithRetries(device);
 
     if (result.success) {
-      _isConnected = true;
-      selectedDevice = device;
       selectedDeviceNotifier.value = device;
       _userInitiatedDisconnect = false;
-      _hasVibrated = false;
-      _reconnectionAttempts = 0;
-      isReconnectingNotifier.value = false;
-      _isReconnecting = false;
-      _isInRetryMode = false;
-    }
-
-    if (!result.success &&
-        _reconnectionAttempts >= _maxReconnectionAttempts) {
-      _handlePermanentConnectionLoss();
+      _resetReconnectionCounters();
+      _setConnectionPhase(BleConnectionPhase.connected);
     }
   }
 
@@ -537,12 +506,7 @@ class BleBloc {
     _reconnectionListener = null;
 
     _clearCharacteristicStreams();
-
-    _isReconnecting = false;
-    _isInRetryMode = false;
-    _reconnectionAttempts = 0;
-    _hasVibrated = false;
-    isReconnectingNotifier.value = false;
+    _resetReconnectionCounters();
     isConnectingNotifier.value = false;
   }
 
@@ -556,9 +520,15 @@ class BleBloc {
   }
 
   void _resetReconnectionState() {
-    _isReconnecting = false;
-    _isInRetryMode = false;
-    _reconnectionAttempts = 0;
+    _resetReconnectionCounters();
+    if (_connectionPhase == BleConnectionPhase.reconnecting) {
+      _setConnectionPhase(BleConnectionPhase.idle);
+    } else {
+      isReconnectingNotifier.value = false;
+    }
+  }
+
+  void _resetReconnectionCounters() {
     _hasVibrated = false;
     isReconnectingNotifier.value = false;
   }
@@ -620,13 +590,14 @@ class BleBloc {
     _adapterStateSubscription?.cancel();
     _cancelScanSubscriptions();
     _reconnectionListener?.cancel();
-    _devicesListController.close();
     _clearCharacteristicStreams();
-    selectedDeviceNotifier.dispose();
     isBluetoothEnabledNotifier.dispose();
     isScanningNotifier.dispose();
     isConnectingNotifier.dispose();
     isReconnectingNotifier.dispose();
+    connectionPhaseNotifier.dispose();
+    selectedDeviceNotifier.dispose();
+    discoveredDevicesNotifier.dispose();
     availableCharacteristics.dispose();
     characteristicStreamsVersion.dispose();
     connectionErrorNotifier.dispose();

--- a/lib/blocs/sensor_bloc.dart
+++ b/lib/blocs/sensor_bloc.dart
@@ -39,8 +39,8 @@ class SensorBloc with ChangeNotifier {
     _initializeSensors();
 
     _selectedDeviceListener = () {
-      if (bleBloc.selectedDevice != null &&
-          bleBloc.selectedDevice!.isConnected) {
+      final device = bleBloc.selectedDeviceNotifier.value;
+      if (device != null && device.isConnected) {
         _startListening();
         if (!geolocationBloc.isListening) {
           geolocationBloc.startListening().catchError((error, stackTrace) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,7 +131,7 @@ class _SenseBoxBikeAppState extends State<SenseBoxBikeApp> {
 
           final fullId = "senseBox:bike [$id]";
           debugPrint('Connecting to $fullId');
-          await _bleBloc!.connectToId(fullId, context);
+          await _bleBloc!.connectToId(fullId);
           await Future.delayed(const Duration(seconds: 2));
           _recordingBloc!.startRecording();
         }
@@ -192,7 +192,7 @@ class _SenseBoxBikeAppState extends State<SenseBoxBikeApp> {
         ChangeNotifierProvider.value(value: _settingsBloc!),
         ChangeNotifierProvider.value(value: _trackBloc!),
         ChangeNotifierProvider.value(value: _recordingBloc!),
-        ChangeNotifierProvider.value(value: _bleBloc!),
+        Provider<BleBloc>.value(value: _bleBloc!),
         ChangeNotifierProvider.value(value: _geolocationBloc!),
         ChangeNotifierProvider.value(value: _sensorBloc!),
         ChangeNotifierProvider.value(value: _openSenseMapBloc!),

--- a/lib/models/ble_connection_phase.dart
+++ b/lib/models/ble_connection_phase.dart
@@ -1,0 +1,6 @@
+enum BleConnectionPhase {
+  idle,
+  connecting,
+  connected,
+  reconnecting,
+}

--- a/lib/models/ble_connection_result.dart
+++ b/lib/models/ble_connection_result.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 enum BleConnectionFailureReason {
   noService,
   noCharacteristics,
@@ -10,87 +8,26 @@ enum BleConnectionFailureReason {
   bluetoothError,
 }
 
-class BleCharacteristicProbeResult {
-  final String uuid;
-  final bool isValid;
-  final BleConnectionFailureReason? reason;
-
-  const BleCharacteristicProbeResult({
-    required this.uuid,
-    required this.isValid,
-    this.reason,
-  });
-}
-
 class BleConnectionResult {
   final bool success;
-  final bool needsUserDecision;
-  final List<BleCharacteristicProbeResult> probes;
   final BleConnectionFailureReason? failureReason;
 
   const BleConnectionResult({
     required this.success,
-    this.needsUserDecision = false,
-    this.probes = const [],
     this.failureReason,
   });
 
-  factory BleConnectionResult.fullSuccess({
-    List<BleCharacteristicProbeResult> probes = const [],
-  }) {
-    return BleConnectionResult(success: true, probes: probes);
-  }
-
-  factory BleConnectionResult.needsUserDecision({
-    required List<BleCharacteristicProbeResult> probes,
-  }) {
-    return BleConnectionResult(
-      success: false,
-      needsUserDecision: true,
-      probes: probes,
-    );
+  factory BleConnectionResult.fullSuccess() {
+    return const BleConnectionResult(success: true);
   }
 
   factory BleConnectionResult.failure({
     required BleConnectionFailureReason reason,
-    List<BleCharacteristicProbeResult> probes = const [],
   }) {
     return BleConnectionResult(
       success: false,
       failureReason: reason,
-      probes: probes,
     );
-  }
-
-  List<String> get validUuids =>
-      probes.where((p) => p.isValid).map((p) => p.uuid).toList();
-
-  List<String> get failedUuids =>
-      probes.where((p) => !p.isValid).map((p) => p.uuid).toList();
-
-  static BleConnectionFailureReason aggregateFailureReason(
-    List<BleCharacteristicProbeResult> probes,
-  ) {
-    if (probes.isEmpty) {
-      return BleConnectionFailureReason.noData;
-    }
-
-    final reasons = probes
-        .where((p) => !p.isValid && p.reason != null)
-        .map((p) => p.reason!)
-        .toList();
-
-    if (reasons.isEmpty) {
-      return BleConnectionFailureReason.noData;
-    }
-
-    if (reasons.every((r) => r == BleConnectionFailureReason.invalidData)) {
-      return BleConnectionFailureReason.invalidData;
-    }
-    if (reasons.any((r) => r == BleConnectionFailureReason.noData)) {
-      return BleConnectionFailureReason.noData;
-    }
-    return BleConnectionFailureReason.invalidData;
   }
 
   static BleConnectionFailureReason fromException(Object error) {
@@ -104,12 +41,4 @@ class BleConnectionResult {
     }
     return BleConnectionFailureReason.bluetoothError;
   }
-}
-
-/// Returns true when a BLE notify/read payload looks like real sensor data.
-bool isValidBleCharacteristicPayload(Uint8List data) {
-  if (data.isEmpty || data.length < 4) {
-    return false;
-  }
-  return !data.every((byte) => byte == 0);
 }

--- a/lib/ui/screens/app_home.dart
+++ b/lib/ui/screens/app_home.dart
@@ -20,19 +20,6 @@ class _AppHomeState extends State<AppHome> {
   final GlobalKey<TracksScreenState> _tracksScreenKey =
       GlobalKey<TracksScreenState>();
 
-  late final List<Widget> _pages;
-
-  @override
-  void initState() {
-    super.initState();
-    _pages = [
-      const HomeScreen(),
-      TracksScreen(key: _tracksScreenKey),
-      const SettingsScreen(),
-      const LoginScreen(),
-    ];
-  }
-
   @override
   void initState() {
     super.initState();
@@ -46,7 +33,12 @@ class _AppHomeState extends State<AppHome> {
     return Scaffold(
       body: IndexedStack(
         index: _selectedIndex,
-        children: _pages,
+        children: [
+          HomeScreen(isMapActive: _selectedIndex == 0),
+          TracksScreen(key: _tracksScreenKey),
+          const SettingsScreen(),
+          const LoginScreen(),
+        ],
       ),
       bottomNavigationBar: Container(
         decoration: const BoxDecoration(
@@ -65,11 +57,10 @@ class _AppHomeState extends State<AppHome> {
             onDestinationSelected: (value) {
               setState(() {
                 _selectedIndex = value;
-                // Refresh tracks when navigating to tracks tab
-                if (value == 1) {
-                  _tracksScreenKey.currentState?.refreshTracks();
-                }
               });
+              if (value == 1) {
+                _tracksScreenKey.currentState?.refreshTracks();
+              }
             },
             selectedIndex: _selectedIndex,
             destinations: [

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -1,5 +1,5 @@
 import 'dart:math';
-import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
 import 'package:provider/provider.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/blocs/configuration_bloc.dart';
@@ -20,12 +20,14 @@ import 'package:sensebox_bike/ui/screens/settings_screen.dart';
 
 // HomeScreen now delegates sections to smaller widgets
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+  final bool isMapActive;
+
+  const HomeScreen({super.key, this.isMapActive = true});
 
   @override
   Widget build(BuildContext context) {
     final BleBloc bleBloc = Provider.of<BleBloc>(context);
-    final RecordingBloc recordingBloc = Provider.of<RecordingBloc>(context);
+    final RecordingBloc recordingBloc = context.read<RecordingBloc>();
     final SensorBloc sensorBloc = Provider.of<SensorBloc>(context);
 
     recordingBloc.setContext(context);
@@ -62,9 +64,9 @@ class HomeScreen extends StatelessWidget {
                         (bleBloc.isConnected ? 0.65 : 0.85),
                     child: Stack(
                       children: [
-                        const SizedBox(
+                        SizedBox(
                           width: double.infinity,
-                          child: GeolocationMapWidget(), // The map
+                          child: GeolocationMapWidget(isActive: isMapActive),
                         ),
                         const Positioned(
                           bottom: 0,
@@ -89,24 +91,31 @@ class HomeScreen extends StatelessWidget {
                 ),
                 SliverSafeArea(
                   minimum: const EdgeInsets.fromLTRB(8, 0, 8, 8),
-                  sliver: ValueListenableBuilder<BluetoothDevice?>(
-                    valueListenable: bleBloc.selectedDeviceNotifier,
-                    builder: (context, device, child) {
-                      // Only show sensor area if device is connected and not in error state
-                      if (device == null ||
-                          bleBloc.connectionErrorNotifier.value) {
-                        return SliverToBoxAdapter(child: SizedBox.shrink());
+                  sliver: ValueListenableBuilder<BleConnectionPhase>(
+                    valueListenable: bleBloc.connectionPhaseNotifier,
+                    builder: (context, phase, child) {
+                      if (phase != BleConnectionPhase.connected) {
+                        return const SliverToBoxAdapter(
+                            child: SizedBox.shrink());
                       }
 
-                      // Check if there are actually any sensor widgets available
-                      final widgets = sensorBloc.getSensorWidgets();
-                      if (widgets.isEmpty) {
-                        // Connected but no sensor data available: show nothing
-                        return SliverToBoxAdapter(child: SizedBox.shrink());
-                      }
+                      return ValueListenableBuilder<int>(
+                        valueListenable: bleBloc.characteristicStreamsVersion,
+                        builder: (context, _, child) {
+                          if (bleBloc.connectionErrorNotifier.value) {
+                            return const SliverToBoxAdapter(
+                                child: SizedBox.shrink());
+                          }
 
-                      // Connected and has sensor data: show sensor grid
-                      return _SensorGrid(sensorBloc: sensorBloc);
+                          final widgets = sensorBloc.getSensorWidgets();
+                          if (widgets.isEmpty) {
+                            return const SliverToBoxAdapter(
+                                child: SizedBox.shrink());
+                          }
+
+                          return _SensorGrid(sensorBloc: sensorBloc);
+                        },
+                      );
                     },
                   ),
                 ),
@@ -295,13 +304,13 @@ class _FloatingButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: bleBloc.isReconnectingNotifier,
-      builder: (context, isReconnecting, child) {
+    return ValueListenableBuilder<BleConnectionPhase>(
+      valueListenable: bleBloc.connectionPhaseNotifier,
+      builder: (context, phase, child) {
+        final isReconnecting = phase == BleConnectionPhase.reconnecting;
         return ValueListenableBuilder(
           valueListenable: bleBloc.selectedDeviceNotifier,
           builder: (context, selectedDevice, child) {
-            // Show buttons if device is connected or if reconnecting
             if (selectedDevice == null && !isReconnecting) {
               return Column(
                 spacing: 12,
@@ -351,9 +360,10 @@ class _ConnectButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: bleBloc.isConnectingNotifier,
-      builder: (context, isConnecting, child) {
+    return ValueListenableBuilder<BleConnectionPhase>(
+      valueListenable: bleBloc.connectionPhaseNotifier,
+      builder: (context, phase, child) {
+        final isConnecting = phase == BleConnectionPhase.connecting;
         return ValueListenableBuilder<bool>(
           valueListenable: bleBloc.isBluetoothEnabledNotifier,
           builder: (context, isBluetoothEnabled, child) {
@@ -447,29 +457,33 @@ class _StartStopButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final canStartRecording =
-        recordingBloc.isRecording || bleBloc.isReadyForRecording;
+    return ValueListenableBuilder<bool>(
+      valueListenable: recordingBloc.isRecordingNotifier,
+      builder: (context, isRecording, child) {
+        final canStartRecording =
+            isRecording || bleBloc.isReadyForRecording;
 
-    return FilledButton.icon(
-      style: const ButtonStyle(
-        padding: WidgetStatePropertyAll(
-          EdgeInsets.symmetric(vertical: 12, horizontal: 16),
-        ),
-      ),
-      label: Text(recordingBloc.isRecording
-          ? AppLocalizations.of(context)!.connectionButtonStop
-          : AppLocalizations.of(context)!.connectionButtonStart),
-      icon: Icon(
-          recordingBloc.isRecording ? Icons.stop : Icons.fiber_manual_record),
-      onPressed: isReconnecting || !canStartRecording
-          ? null
-          : () async {
-              if (recordingBloc.isRecording) {
-                await recordingBloc.stopRecording();
-              } else {
-                await recordingBloc.startRecording();
-              }
-            },
+        return FilledButton.icon(
+          style: const ButtonStyle(
+            padding: WidgetStatePropertyAll(
+              EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+            ),
+          ),
+          label: Text(isRecording
+              ? AppLocalizations.of(context)!.connectionButtonStop
+              : AppLocalizations.of(context)!.connectionButtonStart),
+          icon: Icon(isRecording ? Icons.stop : Icons.fiber_manual_record),
+          onPressed: isReconnecting || !canStartRecording
+              ? null
+              : () async {
+                  if (isRecording) {
+                    await recordingBloc.stopRecording();
+                  } else {
+                    await recordingBloc.startRecording();
+                  }
+                },
+        );
+      },
     );
   }
 }
@@ -482,9 +496,10 @@ class _DisconnectButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: bleBloc.isReconnectingNotifier,
-      builder: (context, isReconnecting, child) {
+    return ValueListenableBuilder<BleConnectionPhase>(
+      valueListenable: bleBloc.connectionPhaseNotifier,
+      builder: (context, phase, child) {
+        final isReconnecting = phase == BleConnectionPhase.reconnecting;
         return OutlinedButton.icon(
           style: OutlinedButton.styleFrom(
             backgroundColor: Theme.of(context).colorScheme.surfaceContainer,

--- a/lib/ui/widgets/home/ble_connection_dialogs.dart
+++ b/lib/ui/widgets/home/ble_connection_dialogs.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/l10n/app_localizations.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
 import 'package:sensebox_bike/ui/widgets/common/app_dialog.dart';
@@ -29,7 +28,6 @@ String bleConnectionFailureMessage(
 
 Future<void> handleBleConnectionResult({
   required BuildContext context,
-  required BleBloc bleBloc,
   required BluetoothDevice device,
   required BleConnectionResult result,
 }) async {

--- a/lib/ui/widgets/home/ble_connection_dialogs.dart
+++ b/lib/ui/widgets/home/ble_connection_dialogs.dart
@@ -60,7 +60,7 @@ Future<void> showBleConnectionFailedDialog(
   return showAppDialog(
     context: context,
     title: localizations.errorBleConnectionAttemptFailedTitle,
-    message: localizations.errorBleConnectionAttemptFailed,
+    message: bleConnectionFailureMessage(localizations, reason),
     type: AppDialogType.error,
   ).then((_) {});
 }

--- a/lib/ui/widgets/home/ble_connection_dialogs.dart
+++ b/lib/ui/widgets/home/ble_connection_dialogs.dart
@@ -4,7 +4,6 @@ import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/l10n/app_localizations.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
 import 'package:sensebox_bike/ui/widgets/common/app_dialog.dart';
-import 'package:sensebox_bike/utils/sensor_utils.dart';
 
 String bleConnectionFailureMessage(
   AppLocalizations localizations,
@@ -28,26 +27,6 @@ String bleConnectionFailureMessage(
   }
 }
 
-Future<bool> showBlePartialConnectionDialog(
-  BuildContext context,
-  BleConnectionResult result,
-) {
-  final localizations = AppLocalizations.of(context)!;
-  final failedNames = result.failedUuids
-      .map(getSensorDisplayNameByUuid)
-      .toSet()
-      .join(', ');
-
-  return showAppDialog(
-    context: context,
-    title: localizations.blePartialConnectionTitle,
-    message: localizations.blePartialConnectionBody(failedNames),
-    type: AppDialogType.confirmation,
-    cancelLabel: localizations.blePartialConnectionCancel,
-    confirmLabel: localizations.blePartialConnectionContinue,
-  ).then((value) => value ?? false);
-}
-
 Future<void> handleBleConnectionResult({
   required BuildContext context,
   required BleBloc bleBloc,
@@ -55,20 +34,6 @@ Future<void> handleBleConnectionResult({
   required BleConnectionResult result,
 }) async {
   if (result.success) {
-    return;
-  }
-
-  if (result.needsUserDecision) {
-    if (!context.mounted) return;
-
-    final shouldContinue = await showBlePartialConnectionDialog(context, result);
-    if (!context.mounted) return;
-
-    if (shouldContinue) {
-      await bleBloc.finalizePartialConnection(device, context);
-    } else {
-      bleBloc.disconnectDevice();
-    }
     return;
   }
 

--- a/lib/ui/widgets/home/ble_device_selection_dialog_widget.dart
+++ b/lib/ui/widgets/home/ble_device_selection_dialog_widget.dart
@@ -50,7 +50,6 @@ void showDeviceSelectionDialog(BuildContext context, BleBloc bleBloc) async {
 
   await handleBleConnectionResult(
     context: context,
-    bleBloc: bleBloc,
     device: attempt.device,
     result: attempt.result,
   );
@@ -78,8 +77,7 @@ class _DeviceSelectionSheetState extends State<DeviceSelectionSheet> {
 
     setState(() => _isConnecting = true);
 
-    final result =
-        await widget.bleBloc.connectToDevice(device, context);
+    final result = await widget.bleBloc.connectToDevice(device);
 
     if (!mounted) return;
 

--- a/lib/ui/widgets/home/ble_device_selection_dialog_widget.dart
+++ b/lib/ui/widgets/home/ble_device_selection_dialog_widget.dart
@@ -109,37 +109,20 @@ class _DeviceSelectionSheetState extends State<DeviceSelectionSheet> {
             top: spacing * 4, bottom: spacing, left: spacing, right: spacing),
         child: SizedBox(
             height: MediaQuery.of(context).size.height * 0.6,
-            child: StreamBuilder<List<BluetoothDevice>>(
-              stream: widget.bleBloc.devicesListStream,
-              builder: (context, snapshot) {
+            child: ValueListenableBuilder<List<BluetoothDevice>>(
+              valueListenable: widget.bleBloc.discoveredDevicesNotifier,
+              builder: (context, devices, child) {
                 final colorScheme = Theme.of(context).colorScheme;
 
-                if (snapshot.connectionState == ConnectionState.waiting &&
-                    !snapshot.hasData) {
-                  return Center(
-                      child: CircularProgressIndicator(
-                          color: colorScheme.primaryFixedDim));
-                }
-
-                if (snapshot.hasError) {
-                  return Center(
-                    child: Text("Stream Error: ${snapshot.error.toString()}"),
-                  );
-                }
-
-                final devices = snapshot.data;
-
-                if (devices == null || devices.isEmpty) {
+                if (devices.isEmpty) {
                   return ValueListenableBuilder<bool>(
                     valueListenable: widget.bleBloc.isScanningNotifier,
                     builder: (context, isScanning, child) {
-                      final colorScheme = Theme.of(context).colorScheme;
                       if (isScanning) {
                         return Center(
                             child: CircularProgressIndicator(
                                 color: colorScheme.primaryFixedDim));
                       } else {
-                        // Not scanning, and no devices found.
                         return EmptyStateMessage(
                           icon: Icons.sensors_off_outlined,
                           message: localizations.noBleDevicesFound,

--- a/test/blocs/ble_bloc_test.dart
+++ b/test/blocs/ble_bloc_test.dart
@@ -1,8 +1,9 @@
-import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
+import '../helpers/fake_flutter_blue_plus_platform.dart';
 import '../mocks.dart';
 
 void main() {
@@ -12,74 +13,146 @@ void main() {
 
     setUpAll(() {
       registerFallbackValue(MockBluetoothDevice());
-      registerFallbackValue(FakeBuildContext());
     });
 
-    setUp(() {
-      mockSettingsBloc = MockSettingsBloc();
-      bleBloc = MockBleBloc();
+    group('MockBleBloc', () {
+      setUp(() {
+        mockSettingsBloc = MockSettingsBloc();
+        bleBloc = MockBleBloc();
+      });
+
+      tearDown(() {
+        bleBloc.dispose();
+      });
+
+      group('Initialization', () {
+        test('initializes with correct default values', () {
+          expect(bleBloc.isBluetoothEnabledNotifier.value, isFalse);
+          expect(bleBloc.isScanningNotifier.value, isFalse);
+          expect(bleBloc.isConnectingNotifier.value, isFalse);
+          expect(bleBloc.isReconnectingNotifier.value, isFalse);
+          expect(bleBloc.connectionPhaseNotifier.value,
+              BleConnectionPhase.idle);
+          expect(bleBloc.selectedDeviceNotifier.value, isNull);
+          expect(bleBloc.discoveredDevicesNotifier.value, isEmpty);
+          expect(bleBloc.availableCharacteristics.value, isEmpty);
+          expect(bleBloc.characteristicStreamsVersion.value, equals(0));
+          expect(bleBloc.connectionErrorNotifier.value, isFalse);
+          expect(bleBloc.isConnected, isFalse);
+        });
+      });
+
+      group('Bluetooth Status', () {
+        test('updateBluetoothStatus updates notifier', () {
+          bleBloc.updateBluetoothStatus(true);
+
+          expect(bleBloc.isBluetoothEnabledNotifier.value, isTrue);
+        });
+      });
+
+      group('Connection State Management', () {
+        test('resetConnectionError clears connection error state', () {
+          bleBloc.connectionErrorNotifier.value = true;
+          bleBloc.resetConnectionError();
+          expect(bleBloc.connectionErrorNotifier.value, isFalse);
+        });
+      });
+
+      group('Device Management', () {
+        test('startScanning disconnects when a device is selected', () {
+          final mockDevice = MockBluetoothDevice();
+          bleBloc.selectedDeviceNotifier.value = mockDevice;
+
+          bleBloc.startScanning();
+
+          expect(bleBloc.selectedDeviceNotifier.value, isNull);
+        });
+      });
     });
 
-    tearDown(() {
-      bleBloc.dispose();
-    });
+    group('BleBloc instance', () {
+      late FakeFlutterBluePlusPlatform fakePlatform;
 
-    group('Initialization', () {
-      test('initializes with correct default values', () {
-        expect(bleBloc.isBluetoothEnabledNotifier.value, isFalse);
-        expect(bleBloc.isScanningNotifier.value, isFalse);
-        expect(bleBloc.isConnectingNotifier.value, isFalse);
-        expect(bleBloc.isReconnectingNotifier.value, isFalse);
+      setUp(() async {
+        fakePlatform = FakeFlutterBluePlusPlatform();
+        installFakeFlutterBluePlusPlatform(fakePlatform);
+        mockSettingsBloc = MockSettingsBloc();
+        bleBloc = BleBloc(mockSettingsBloc);
+        await _waitForBleBlocInit(bleBloc);
+      });
+
+      tearDown(() {
+        bleBloc.dispose();
+        fakePlatform.dispose();
+      });
+
+      test('starts in idle phase with empty discovered devices', () {
+        expect(bleBloc.connectionPhaseNotifier.value, BleConnectionPhase.idle);
+        expect(bleBloc.discoveredDevicesNotifier.value, isEmpty);
         expect(bleBloc.selectedDeviceNotifier.value, isNull);
-        expect(bleBloc.availableCharacteristics.value, isEmpty);
-        expect(bleBloc.characteristicStreamsVersion.value, equals(0));
-        expect(bleBloc.connectionErrorNotifier.value, isFalse);
         expect(bleBloc.isConnected, isFalse);
-        expect(bleBloc.devicesList, isEmpty);
-      });
-    });
-
-    group('Bluetooth Status', () {
-      test('updateBluetoothStatus updates notifier', () {
-        bleBloc.updateBluetoothStatus(true);
-
-        expect(bleBloc.isBluetoothEnabledNotifier.value, isTrue);
-      });
-    });
-
-    group('Connection State Management', () {
-      test('resetConnectionError clears connection error state', () {
-        bleBloc.connectionErrorNotifier.value = true;
-        bleBloc.resetConnectionError();
-        expect(bleBloc.connectionErrorNotifier.value, isFalse);
       });
 
-    });
-
-    group('Error Handling', () {
-      test('connectionErrorNotifier can be set and reset', () {
-        bleBloc.connectionErrorNotifier.value = true;
-        expect(bleBloc.connectionErrorNotifier.value, isTrue);
-        
-        bleBloc.resetConnectionError();
-        expect(bleBloc.connectionErrorNotifier.value, isFalse);
-      });
-
-    });
-
-    group('Device Management', () {
-      test('devicesListStream provides stream of device lists', () {
-        expect(bleBloc.devicesListStream, isA<Stream<List<dynamic>>>());
-      });
-
-      test('startScanning disconnects when a device is selected', () {
+      test('disconnectDevice clears selected device and returns to idle', () {
         final mockDevice = MockBluetoothDevice();
-        bleBloc.selectedDevice = mockDevice;
+        when(() => mockDevice.disconnect()).thenAnswer((_) async {});
+
         bleBloc.selectedDeviceNotifier.value = mockDevice;
+        bleBloc.disconnectDevice();
 
-        bleBloc.startScanning();
+        expect(bleBloc.selectedDeviceNotifier.value, isNull);
+        expect(bleBloc.connectionPhaseNotifier.value, BleConnectionPhase.idle);
+        expect(bleBloc.isConnected, isFalse);
+      });
 
-        expect(bleBloc.selectedDevice, isNull);
+      test('resetConnectionError clears permanent connection error flag', () {
+        bleBloc.connectionErrorNotifier.value = true;
+
+        bleBloc.resetConnectionError();
+
+        expect(bleBloc.connectionErrorNotifier.value, isFalse);
+      });
+
+      test('isReadyForRecording is false without a connected device', () {
+        expect(bleBloc.isReadyForRecording, isFalse);
+      });
+
+      test('startScanning populates discoveredDevicesNotifier for senseBox devices',
+          () async {
+        await bleBloc.startScanning();
+
+        fakePlatform.emitScanResult(
+          remoteId: '00:11:22:33:44:55',
+          platformName: 'senseBox:bike',
+        );
+        fakePlatform.emitScanResult(
+          remoteId: '00:11:22:33:44:66',
+          platformName: 'OtherDevice',
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bleBloc.discoveredDevicesNotifier.value, hasLength(1));
+        expect(
+          bleBloc.discoveredDevicesNotifier.value.first.platformName,
+          'senseBox:bike',
+        );
+
+        await bleBloc.stopScanning();
+      });
+
+      test('connectToDevice returns failure when platform connect fails',
+          () async {
+        fakePlatform.dispose();
+        fakePlatform = FakeFlutterBluePlusPlatform(connectSucceeds: false);
+        installFakeFlutterBluePlusPlatform(fakePlatform);
+
+        final device = BluetoothDevice.fromId('00:11:22:33:44:55');
+
+        final result = await bleBloc.connectToDevice(device);
+
+        expect(result.success, isFalse);
+        expect(bleBloc.connectionPhaseNotifier.value, BleConnectionPhase.idle);
         expect(bleBloc.selectedDeviceNotifier.value, isNull);
       });
     });
@@ -87,5 +160,13 @@ void main() {
 }
 
 class MockBluetoothDevice extends Mock implements BluetoothDevice {}
-class FakeBuildContext extends Fake implements BuildContext {}
 
+Future<void> _waitForBleBlocInit(BleBloc bloc) async {
+  for (var i = 0; i < 50; i++) {
+    if (bloc.isBluetoothEnabledNotifier.value) {
+      return;
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail('BleBloc initialization did not complete');
+}

--- a/test/blocs/ble_bloc_test.dart
+++ b/test/blocs/ble_bloc_test.dart
@@ -40,16 +40,10 @@ void main() {
     });
 
     group('Bluetooth Status', () {
-      test('updateBluetoothStatus updates notifier and notifies listeners', () {
-        bool listenerCalled = false;
-        bleBloc.addListener(() {
-          listenerCalled = true;
-        });
-
+      test('updateBluetoothStatus updates notifier', () {
         bleBloc.updateBluetoothStatus(true);
 
         expect(bleBloc.isBluetoothEnabledNotifier.value, isTrue);
-        expect(listenerCalled, isTrue);
       });
     });
 

--- a/test/blocs/ble_bloc_test.dart
+++ b/test/blocs/ble_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -15,9 +17,8 @@ void main() {
       registerFallbackValue(MockBluetoothDevice());
     });
 
-    group('MockBleBloc', () {
+    group('MockBleBloc smoke', () {
       setUp(() {
-        mockSettingsBloc = MockSettingsBloc();
         bleBloc = MockBleBloc();
       });
 
@@ -25,48 +26,17 @@ void main() {
         bleBloc.dispose();
       });
 
-      group('Initialization', () {
-        test('initializes with correct default values', () {
-          expect(bleBloc.isBluetoothEnabledNotifier.value, isFalse);
-          expect(bleBloc.isScanningNotifier.value, isFalse);
-          expect(bleBloc.isConnectingNotifier.value, isFalse);
-          expect(bleBloc.isReconnectingNotifier.value, isFalse);
-          expect(bleBloc.connectionPhaseNotifier.value,
-              BleConnectionPhase.idle);
-          expect(bleBloc.selectedDeviceNotifier.value, isNull);
-          expect(bleBloc.discoveredDevicesNotifier.value, isEmpty);
-          expect(bleBloc.availableCharacteristics.value, isEmpty);
-          expect(bleBloc.characteristicStreamsVersion.value, equals(0));
-          expect(bleBloc.connectionErrorNotifier.value, isFalse);
-          expect(bleBloc.isConnected, isFalse);
-        });
-      });
+      test('exposes idle defaults and disconnect resets phase', () {
+        expect(bleBloc.connectionPhaseNotifier.value, BleConnectionPhase.idle);
+        expect(bleBloc.discoveredDevicesNotifier.value, isEmpty);
+        expect(bleBloc.isConnected, isFalse);
 
-      group('Bluetooth Status', () {
-        test('updateBluetoothStatus updates notifier', () {
-          bleBloc.updateBluetoothStatus(true);
+        bleBloc.connectionPhaseNotifier.value = BleConnectionPhase.connected;
+        expect(bleBloc.isConnected, isTrue);
 
-          expect(bleBloc.isBluetoothEnabledNotifier.value, isTrue);
-        });
-      });
-
-      group('Connection State Management', () {
-        test('resetConnectionError clears connection error state', () {
-          bleBloc.connectionErrorNotifier.value = true;
-          bleBloc.resetConnectionError();
-          expect(bleBloc.connectionErrorNotifier.value, isFalse);
-        });
-      });
-
-      group('Device Management', () {
-        test('startScanning disconnects when a device is selected', () {
-          final mockDevice = MockBluetoothDevice();
-          bleBloc.selectedDeviceNotifier.value = mockDevice;
-
-          bleBloc.startScanning();
-
-          expect(bleBloc.selectedDeviceNotifier.value, isNull);
-        });
+        bleBloc.disconnectDevice();
+        expect(bleBloc.connectionPhaseNotifier.value, BleConnectionPhase.idle);
+        expect(bleBloc.isConnected, isFalse);
       });
     });
 
@@ -78,12 +48,26 @@ void main() {
         installFakeFlutterBluePlusPlatform(fakePlatform);
         mockSettingsBloc = MockSettingsBloc();
         bleBloc = BleBloc(mockSettingsBloc);
-        await _waitForBleBlocInit(bleBloc);
+        await waitForBleBlocInit(bleBloc);
       });
 
       tearDown(() {
         bleBloc.dispose();
         fakePlatform.dispose();
+      });
+
+      test('connectToDevice transitions to connected on success', () async {
+        final device = BluetoothDevice.fromId('00:11:22:33:44:55');
+
+        final result = await bleBloc.connectToDevice(device);
+
+        expect(result.success, isTrue, reason: '${result.failureReason}');
+        expect(bleBloc.connectionPhaseNotifier.value,
+            BleConnectionPhase.connected);
+        expect(bleBloc.selectedDeviceNotifier.value, isNotNull);
+        expect(bleBloc.isConnected, isTrue);
+        expect(bleBloc.availableCharacteristics.value, isNotEmpty);
+        expect(bleBloc.isReadyForRecording, isTrue);
       });
 
       test('starts in idle phase with empty discovered devices', () {
@@ -140,14 +124,27 @@ void main() {
 
         await bleBloc.stopScanning();
       });
+    });
+
+    group('BleBloc connect failures', () {
+      late FakeFlutterBluePlusPlatform fakePlatform;
+
+      setUp(() async {
+        fakePlatform = FakeFlutterBluePlusPlatform(connectSucceeds: false);
+        installFakeFlutterBluePlusPlatform(fakePlatform);
+        mockSettingsBloc = MockSettingsBloc();
+        bleBloc = BleBloc(mockSettingsBloc);
+        await waitForBleBlocInit(bleBloc);
+      });
+
+      tearDown(() {
+        bleBloc.dispose();
+        fakePlatform.dispose();
+      });
 
       test('connectToDevice returns failure when platform connect fails',
           () async {
-        fakePlatform.dispose();
-        fakePlatform = FakeFlutterBluePlusPlatform(connectSucceeds: false);
-        installFakeFlutterBluePlusPlatform(fakePlatform);
-
-        final device = BluetoothDevice.fromId('00:11:22:33:44:55');
+        final device = BluetoothDevice.fromId('00:11:22:33:44:66');
 
         final result = await bleBloc.connectToDevice(device);
 
@@ -161,12 +158,25 @@ void main() {
 
 class MockBluetoothDevice extends Mock implements BluetoothDevice {}
 
-Future<void> _waitForBleBlocInit(BleBloc bloc) async {
-  for (var i = 0; i < 50; i++) {
-    if (bloc.isBluetoothEnabledNotifier.value) {
-      return;
-    }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+Future<void> waitForBleBlocInit(BleBloc bloc) async {
+  if (bloc.isBluetoothEnabledNotifier.value) {
+    return;
   }
-  fail('BleBloc initialization did not complete');
+
+  final completer = Completer<void>();
+  void listener() {
+    if (bloc.isBluetoothEnabledNotifier.value && !completer.isCompleted) {
+      completer.complete();
+    }
+  }
+
+  bloc.isBluetoothEnabledNotifier.addListener(listener);
+  listener();
+
+  await completer.future.timeout(
+    const Duration(seconds: 1),
+    onTimeout: () => fail('BleBloc initialization did not complete'),
+  );
+
+  bloc.isBluetoothEnabledNotifier.removeListener(listener);
 }

--- a/test/helpers/fake_flutter_blue_plus_platform.dart
+++ b/test/helpers/fake_flutter_blue_plus_platform.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter_blue_plus_platform_interface/flutter_blue_plus_platform_interface.dart';
+
+/// Minimal platform fake so [BleBloc] can be tested on the VM.
+final class FakeFlutterBluePlusPlatform extends FlutterBluePlusPlatform {
+  FakeFlutterBluePlusPlatform({
+    this.connectSucceeds = true,
+    this.adapterOn = true,
+  }) {
+    _adapterStateController = StreamController<BmBluetoothAdapterState>.broadcast();
+    _scanResponseController = StreamController<BmScanResponse>.broadcast();
+    _connectionStateController =
+        StreamController<BmConnectionStateResponse>.broadcast();
+
+    if (adapterOn) {
+      _emitAdapterState(BmAdapterStateEnum.on);
+    }
+  }
+
+  final bool connectSucceeds;
+  final bool adapterOn;
+
+  late final StreamController<BmBluetoothAdapterState> _adapterStateController;
+  late final StreamController<BmScanResponse> _scanResponseController;
+  late final StreamController<BmConnectionStateResponse>
+      _connectionStateController;
+
+  final Set<String> _connectedDeviceIds = {};
+
+  void emitScanResult({
+    required String remoteId,
+    required String platformName,
+    String advName = '',
+  }) {
+    _scanResponseController.add(
+      BmScanResponse(
+        advertisements: [
+          BmScanAdvertisement(
+            remoteId: DeviceIdentifier(remoteId),
+            platformName: platformName,
+            advName: advName.isEmpty ? platformName : advName,
+            connectable: true,
+            txPowerLevel: null,
+            appearance: null,
+            manufacturerData: const {},
+            serviceData: const {},
+            serviceUuids: const [],
+            rssi: -50,
+          ),
+        ],
+        success: true,
+        errorCode: 0,
+        errorString: '',
+      ),
+    );
+  }
+
+  void _emitAdapterState(BmAdapterStateEnum state) {
+    _adapterStateController.add(BmBluetoothAdapterState(adapterState: state));
+  }
+
+  @override
+  Stream<BmBluetoothAdapterState> get onAdapterStateChanged =>
+      _adapterStateController.stream;
+
+  @override
+  Stream<BmScanResponse> get onScanResponse => _scanResponseController.stream;
+
+  @override
+  Stream<BmConnectionStateResponse> get onConnectionStateChanged =>
+      _connectionStateController.stream;
+
+  @override
+  Future<BmBluetoothAdapterState> getAdapterState(
+    BmBluetoothAdapterStateRequest request,
+  ) async {
+    return BmBluetoothAdapterState(
+      adapterState:
+          adapterOn ? BmAdapterStateEnum.on : BmAdapterStateEnum.off,
+    );
+  }
+
+  @override
+  Future<bool> setOptions(BmSetOptionsRequest request) async => true;
+
+  @override
+  Future<bool> setLogLevel(BmSetLogLevelRequest request) async => true;
+
+  @override
+  Future<bool> startScan(BmScanSettings request) async => true;
+
+  @override
+  Future<bool> stopScan(BmStopScanRequest request) async => true;
+
+  @override
+  Future<bool> connect(BmConnectRequest request) async {
+    if (!connectSucceeds) {
+      return false;
+    }
+
+    _connectedDeviceIds.add(request.remoteId.str);
+    _connectionStateController.add(
+      BmConnectionStateResponse(
+        remoteId: request.remoteId,
+        connectionState: BmConnectionStateEnum.connected,
+        disconnectReasonCode: null,
+        disconnectReasonString: null,
+      ),
+    );
+    return true;
+  }
+
+  @override
+  Future<bool> disconnect(BmDisconnectRequest request) async {
+    _connectedDeviceIds.remove(request.remoteId.str);
+    _connectionStateController.add(
+      BmConnectionStateResponse(
+        remoteId: request.remoteId,
+        connectionState: BmConnectionStateEnum.disconnected,
+        disconnectReasonCode: null,
+        disconnectReasonString: null,
+      ),
+    );
+    return true;
+  }
+
+  void dispose() {
+    _adapterStateController.close();
+    _scanResponseController.close();
+    _connectionStateController.close();
+  }
+}
+
+void installFakeFlutterBluePlusPlatform([
+  FakeFlutterBluePlusPlatform? platform,
+]) {
+  FlutterBluePlusPlatform.instance =
+      platform ?? FakeFlutterBluePlusPlatform();
+}
+
+void resetFlutterBluePlusPlatform() {
+  FlutterBluePlusPlatform.instance = FakeFlutterBluePlusPlatform();
+}

--- a/test/helpers/fake_flutter_blue_plus_platform.dart
+++ b/test/helpers/fake_flutter_blue_plus_platform.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_blue_plus_platform_interface/flutter_blue_plus_platform_interface.dart';
+import 'package:sensebox_bike/secrets.dart';
+import 'package:sensebox_bike/sensors/temperature_sensor.dart';
 
 /// Minimal platform fake so [BleBloc] can be tested on the VM.
 final class FakeFlutterBluePlusPlatform extends FlutterBluePlusPlatform {
@@ -8,10 +11,15 @@ final class FakeFlutterBluePlusPlatform extends FlutterBluePlusPlatform {
     this.connectSucceeds = true,
     this.adapterOn = true,
   }) {
-    _adapterStateController = StreamController<BmBluetoothAdapterState>.broadcast();
+    _adapterStateController =
+        StreamController<BmBluetoothAdapterState>.broadcast();
     _scanResponseController = StreamController<BmScanResponse>.broadcast();
     _connectionStateController =
         StreamController<BmConnectionStateResponse>.broadcast();
+    _discoveredServicesController =
+        StreamController<BmDiscoverServicesResult>.broadcast();
+    _descriptorWrittenController =
+        StreamController<BmDescriptorData>.broadcast();
 
     if (adapterOn) {
       _emitAdapterState(BmAdapterStateEnum.on);
@@ -25,8 +33,52 @@ final class FakeFlutterBluePlusPlatform extends FlutterBluePlusPlatform {
   late final StreamController<BmScanResponse> _scanResponseController;
   late final StreamController<BmConnectionStateResponse>
       _connectionStateController;
+  late final StreamController<BmDiscoverServicesResult>
+      _discoveredServicesController;
+  late final StreamController<BmDescriptorData> _descriptorWrittenController;
+
+  static final Guid _cccdUuid =
+      Guid('00002902-0000-1000-8000-00805f9b34fb');
 
   final Set<String> _connectedDeviceIds = {};
+
+  static BmCharacteristicProperties get _notifyProperties =>
+      BmCharacteristicProperties(
+        broadcast: false,
+        read: false,
+        writeWithoutResponse: false,
+        write: false,
+        notify: true,
+        indicate: false,
+        authenticatedSignedWrites: false,
+        extendedProperties: false,
+        notifyEncryptionRequired: false,
+        indicateEncryptionRequired: false,
+      );
+
+  static List<BmBluetoothService> senseBoxServicesFor(DeviceIdentifier remoteId) {
+    final serviceUuid = Guid(senseBoxServiceUUID.str);
+    final characteristicUuid =
+        Guid(TemperatureSensor.sensorCharacteristicUuid);
+
+    return [
+      BmBluetoothService(
+        remoteId: remoteId,
+        serviceUuid: serviceUuid,
+        primaryServiceUuid: null,
+        characteristics: [
+          BmBluetoothCharacteristic(
+            remoteId: remoteId,
+            serviceUuid: serviceUuid,
+            characteristicUuid: characteristicUuid,
+            primaryServiceUuid: null,
+            descriptors: const [],
+            properties: _notifyProperties,
+          ),
+        ],
+      ),
+    ];
+  }
 
   void emitScanResult({
     required String remoteId,
@@ -70,6 +122,14 @@ final class FakeFlutterBluePlusPlatform extends FlutterBluePlusPlatform {
   @override
   Stream<BmConnectionStateResponse> get onConnectionStateChanged =>
       _connectionStateController.stream;
+
+  @override
+  Stream<BmDiscoverServicesResult> get onDiscoveredServices =>
+      _discoveredServicesController.stream;
+
+  @override
+  Stream<BmDescriptorData> get onDescriptorWritten =>
+      _descriptorWrittenController.stream;
 
   @override
   Future<BmBluetoothAdapterState> getAdapterState(
@@ -125,10 +185,59 @@ final class FakeFlutterBluePlusPlatform extends FlutterBluePlusPlatform {
     return true;
   }
 
+  @override
+  Future<bool> discoverServices(
+    BmDiscoverServicesRequest request,
+  ) async {
+    if (!_connectedDeviceIds.contains(request.remoteId.str)) {
+      _discoveredServicesController.add(
+        BmDiscoverServicesResult(
+          remoteId: request.remoteId,
+          services: const [],
+          success: false,
+          errorCode: 1,
+          errorString: 'not connected',
+        ),
+      );
+      return false;
+    }
+
+    _discoveredServicesController.add(
+      BmDiscoverServicesResult(
+        remoteId: request.remoteId,
+        services: senseBoxServicesFor(request.remoteId),
+        success: true,
+        errorCode: 0,
+        errorString: '',
+      ),
+    );
+    return true;
+  }
+
+  @override
+  Future<bool> setNotifyValue(BmSetNotifyValueRequest request) async {
+    _descriptorWrittenController.add(
+      BmDescriptorData(
+        remoteId: request.remoteId,
+        serviceUuid: request.serviceUuid,
+        characteristicUuid: request.characteristicUuid,
+        descriptorUuid: _cccdUuid,
+        primaryServiceUuid: request.primaryServiceUuid,
+        value: Uint8List.fromList([1, 0]),
+        success: true,
+        errorCode: 0,
+        errorString: '',
+      ),
+    );
+    return true;
+  }
+
   void dispose() {
     _adapterStateController.close();
     _scanResponseController.close();
     _connectionStateController.close();
+    _discoveredServicesController.close();
+    _descriptorWrittenController.close();
   }
 }
 

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -74,9 +74,6 @@ class MockBleBloc extends Mock implements BleBloc {
   final ValueNotifier<bool> connectionErrorNotifier = ValueNotifier(false);
 
   @override
-  List<String> failedCharacteristicUuids = [];
-
-  @override
   bool get isConnected => false;
 
   @override
@@ -95,12 +92,6 @@ class MockBleBloc extends Mock implements BleBloc {
 
   @override
   Future<BleConnectionResult> connectToDevice(
-      BluetoothDevice device, BuildContext context) async {
-    return BleConnectionResult.fullSuccess();
-  }
-
-  @override
-  Future<BleConnectionResult> finalizePartialConnection(
       BluetoothDevice device, BuildContext context) async {
     return BleConnectionResult.fullSuccess();
   }

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -17,6 +17,7 @@ import 'package:sensebox_bike/services/isar_service/track_service.dart';
 import 'package:sensebox_bike/services/remote_data_service.dart';
 import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
 import 'package:sensebox_bike/blocs/geolocation_bloc.dart';
 import 'package:sensebox_bike/sensors/sensor.dart' as sensors;
@@ -58,8 +59,16 @@ class MockBleBloc extends Mock implements BleBloc {
   final ValueNotifier<bool> isReconnectingNotifier = ValueNotifier(false);
 
   @override
+  final ValueNotifier<BleConnectionPhase> connectionPhaseNotifier =
+      ValueNotifier(BleConnectionPhase.idle);
+
+  @override
   final ValueNotifier<BluetoothDevice?> selectedDeviceNotifier =
       ValueNotifier(null);
+
+  @override
+  final ValueNotifier<List<BluetoothDevice>> discoveredDevicesNotifier =
+      ValueNotifier([]);
 
   @override
   final ValueNotifier<List<BluetoothCharacteristic>> availableCharacteristics =
@@ -75,33 +84,19 @@ class MockBleBloc extends Mock implements BleBloc {
   bool get isConnected => false;
 
   @override
-  List<BluetoothDevice> get devicesList => [];
-
-  @override
-  Stream<List<BluetoothDevice>> get devicesListStream => Stream.value([]);
-
-  @override
-  BluetoothDevice? get selectedDevice => selectedDeviceNotifier.value;
-
-  @override
-  set selectedDevice(BluetoothDevice? device) {
-    selectedDeviceNotifier.value = device;
-  }
-
-  @override
   Future<BleConnectionResult> connectToDevice(BluetoothDevice device) async {
     return BleConnectionResult.fullSuccess();
   }
 
   @override
   void disconnectDevice() {
-    selectedDevice = null;
     selectedDeviceNotifier.value = null;
+    connectionPhaseNotifier.value = BleConnectionPhase.idle;
   }
 
   @override
   Future<void> startScanning() async {
-    if (selectedDevice != null) {
+    if (selectedDeviceNotifier.value != null) {
       disconnectDevice();
     }
   }

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -45,8 +45,6 @@ class MockGeolocationService extends Mock implements GeolocationService {}
 class MockSensorService extends Mock implements SensorService {}
 
 class MockBleBloc extends Mock implements BleBloc {
-  final List<VoidCallback> _listeners = [];
-
   @override
   final ValueNotifier<bool> isBluetoothEnabledNotifier = ValueNotifier(false);
 
@@ -91,8 +89,7 @@ class MockBleBloc extends Mock implements BleBloc {
   }
 
   @override
-  Future<BleConnectionResult> connectToDevice(
-      BluetoothDevice device, BuildContext context) async {
+  Future<BleConnectionResult> connectToDevice(BluetoothDevice device) async {
     return BleConnectionResult.fullSuccess();
   }
 
@@ -117,7 +114,6 @@ class MockBleBloc extends Mock implements BleBloc {
   @override
   void updateBluetoothStatus(bool isEnabled) {
     isBluetoothEnabledNotifier.value = isEnabled;
-    notifyListeners();
   }
 
   @override
@@ -128,24 +124,7 @@ class MockBleBloc extends Mock implements BleBloc {
       Stream.value([]);
 
   @override
-  void addListener(VoidCallback listener) {
-    _listeners.add(listener);
-  }
-
-  @override
-  void removeListener(VoidCallback listener) {
-    _listeners.remove(listener);
-  }
-
-  @override
   void dispose() {}
-
-  @override
-  void notifyListeners() {
-    for (final listener in _listeners) {
-      listener();
-    }
-  }
 
   ValueNotifier<bool> get permanentConnectionLossNotifier =>
       ValueNotifier<bool>(false);

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -53,12 +53,6 @@ class MockBleBloc extends Mock implements BleBloc {
   final ValueNotifier<bool> isScanningNotifier = ValueNotifier(false);
 
   @override
-  final ValueNotifier<bool> isConnectingNotifier = ValueNotifier(false);
-
-  @override
-  final ValueNotifier<bool> isReconnectingNotifier = ValueNotifier(false);
-
-  @override
   final ValueNotifier<BleConnectionPhase> connectionPhaseNotifier =
       ValueNotifier(BleConnectionPhase.idle);
 
@@ -81,12 +75,8 @@ class MockBleBloc extends Mock implements BleBloc {
   final ValueNotifier<bool> connectionErrorNotifier = ValueNotifier(false);
 
   @override
-  bool get isConnected => false;
-
-  @override
-  Future<BleConnectionResult> connectToDevice(BluetoothDevice device) async {
-    return BleConnectionResult.fullSuccess();
-  }
+  bool get isConnected =>
+      connectionPhaseNotifier.value == BleConnectionPhase.connected;
 
   @override
   void disconnectDevice() {
@@ -121,7 +111,8 @@ class MockBleBloc extends Mock implements BleBloc {
   @override
   void dispose() {}
 
-  ValueNotifier<bool> get permanentConnectionLossNotifier =>
+  @override
+  final ValueNotifier<bool> permanentConnectionLossNotifier =
       ValueNotifier<bool>(false);
 }
 

--- a/test/models/ble_connection_result_test.dart
+++ b/test/models/ble_connection_result_test.dart
@@ -1,72 +1,22 @@
-import 'dart:typed_data';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
 
 void main() {
   group('BleConnectionResult', () {
-    test('aggregateFailureReason returns noData when probes are empty', () {
-      expect(
-        BleConnectionResult.aggregateFailureReason([]),
-        BleConnectionFailureReason.noData,
-      );
+    test('fullSuccess marks result as successful', () {
+      final result = BleConnectionResult.fullSuccess();
+
+      expect(result.success, isTrue);
+      expect(result.failureReason, isNull);
     });
 
-    test('aggregateFailureReason returns invalidData when all probes invalid with zeros',
-        () {
-      final probes = [
-        const BleCharacteristicProbeResult(
-          uuid: 'a',
-          isValid: false,
-          reason: BleConnectionFailureReason.invalidData,
-        ),
-        const BleCharacteristicProbeResult(
-          uuid: 'b',
-          isValid: false,
-          reason: BleConnectionFailureReason.invalidData,
-        ),
-      ];
-
-      expect(
-        BleConnectionResult.aggregateFailureReason(probes),
-        BleConnectionFailureReason.invalidData,
+    test('failure exposes the failure reason', () {
+      final result = BleConnectionResult.failure(
+        reason: BleConnectionFailureReason.noData,
       );
-    });
 
-    test('aggregateFailureReason returns noData when any probe timed out', () {
-      final probes = [
-        const BleCharacteristicProbeResult(
-          uuid: 'a',
-          isValid: false,
-          reason: BleConnectionFailureReason.invalidData,
-        ),
-        const BleCharacteristicProbeResult(
-          uuid: 'b',
-          isValid: false,
-          reason: BleConnectionFailureReason.noData,
-        ),
-      ];
-
-      expect(
-        BleConnectionResult.aggregateFailureReason(probes),
-        BleConnectionFailureReason.noData,
-      );
-    });
-
-    test('needsUserDecision result exposes valid and failed uuids', () {
-      final result = BleConnectionResult.needsUserDecision(probes: [
-        const BleCharacteristicProbeResult(uuid: 'valid-uuid', isValid: true),
-        const BleCharacteristicProbeResult(
-          uuid: 'failed-uuid',
-          isValid: false,
-          reason: BleConnectionFailureReason.noData,
-        ),
-      ]);
-
-      expect(result.validUuids, ['valid-uuid']);
-      expect(result.failedUuids, ['failed-uuid']);
-      expect(result.needsUserDecision, isTrue);
       expect(result.success, isFalse);
+      expect(result.failureReason, BleConnectionFailureReason.noData);
     });
   });
 
@@ -86,24 +36,6 @@ void main() {
           Exception('device disconnected'),
         ),
         BleConnectionFailureReason.connectionLost,
-      );
-    });
-  });
-
-  group('isValidBleCharacteristicPayload', () {
-    test('returns false for empty or short payloads', () {
-      expect(isValidBleCharacteristicPayload(Uint8List(0)), isFalse);
-      expect(isValidBleCharacteristicPayload(Uint8List(3)), isFalse);
-    });
-
-    test('returns false for all-zero payloads', () {
-      expect(isValidBleCharacteristicPayload(Uint8List(8)), isFalse);
-    });
-
-    test('returns true for non-zero payload with at least 4 bytes', () {
-      expect(
-        isValidBleCharacteristicPayload(Uint8List.fromList([0, 0, 0, 1])),
-        isTrue,
       );
     });
   });

--- a/test/models/ble_connection_result_test.dart
+++ b/test/models/ble_connection_result_test.dart
@@ -38,5 +38,12 @@ void main() {
         BleConnectionFailureReason.connectionLost,
       );
     });
+
+    test('maps generic errors to bluetoothError', () {
+      expect(
+        BleConnectionResult.fromException(Exception('unknown gatt error')),
+        BleConnectionFailureReason.bluetoothError,
+      );
+    });
   });
 }

--- a/test/ui/widgets/home/ble_connection_dialogs_test.dart
+++ b/test/ui/widgets/home/ble_connection_dialogs_test.dart
@@ -1,0 +1,93 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sensebox_bike/l10n/app_localizations.dart';
+import 'package:sensebox_bike/models/ble_connection_result.dart';
+import 'package:sensebox_bike/ui/widgets/home/ble_connection_dialogs.dart';
+
+void main() {
+  group('bleConnectionFailureMessage', () {
+    late AppLocalizations localizations;
+
+    setUp(() {
+      localizations = lookupAppLocalizations(const Locale('en'));
+    });
+
+    test('maps noService to incompatible device message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.noService,
+        ),
+        localizations.errorBleIncompatibleDevice,
+      );
+    });
+
+    test('maps noCharacteristics to incompatible device message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.noCharacteristics,
+        ),
+        localizations.errorBleIncompatibleDevice,
+      );
+    });
+
+    test('maps noData to no sensor data message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.noData,
+        ),
+        localizations.errorBleNoSensorData,
+      );
+    });
+
+    test('maps invalidData to invalid sensor data message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.invalidData,
+        ),
+        localizations.errorBleInvalidSensorData,
+      );
+    });
+
+    test('maps connectionTimeout to timeout message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.connectionTimeout,
+        ),
+        localizations.errorBleConnectionTimeout,
+      );
+    });
+
+    test('maps connectionLost to connection lost message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.connectionLost,
+        ),
+        localizations.errorBleConnectionLost,
+      );
+    });
+
+    test('maps bluetoothError to generic connection failed message', () {
+      expect(
+        bleConnectionFailureMessage(
+          localizations,
+          BleConnectionFailureReason.bluetoothError,
+        ),
+        localizations.errorBleConnectionFailed,
+      );
+    });
+
+    test('maps null to generic connection failed message', () {
+      expect(
+        bleConnectionFailureMessage(localizations, null),
+        localizations.errorBleConnectionFailed,
+      );
+    });
+  });
+}

--- a/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
+++ b/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
@@ -104,7 +104,7 @@ void main() {
     when(() => device.platformName).thenReturn('TestDevice');
     when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([device]));
     bool connectCalled = false;
-    when(() => bleBloc.connectToDevice(device, any())).thenAnswer((_) async {
+    when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
       connectCalled = true;
       return BleConnectionResult.fullSuccess();
     });
@@ -132,7 +132,7 @@ void main() {
     when(() => device.platformName).thenReturn('TestDevice');
     when(() => bleBloc.startScanning()).thenAnswer((_) async {});
     when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([device]));
-    when(() => bleBloc.connectToDevice(device, any())).thenAnswer((_) async {
+    when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
       return BleConnectionResult.failure(
         reason: BleConnectionFailureReason.connectionTimeout,
       );

--- a/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
+++ b/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
@@ -1,34 +1,35 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:sensebox_bike/blocs/ble_bloc.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
 import 'package:sensebox_bike/models/ble_connection_result.dart';
 import 'package:sensebox_bike/ui/widgets/home/ble_device_selection_dialog_widget.dart';
+import '../../../mocks.dart';
 import '../../../test_helpers.dart';
 
-class MockBleBloc extends Mock implements BleBloc {}
 class MockBluetoothDevice extends Mock implements BluetoothDevice {}
+
 class FakeBuildContext extends Fake implements BuildContext {}
 
 void main() {
   late MockBleBloc bleBloc;
-  late ValueNotifier<List<BluetoothDevice>> discoveredDevices;
 
   setUpAll(() {
     registerFallbackValue(MockBluetoothDevice());
-    registerFallbackValue(FakeBuildContext()); 
+    registerFallbackValue(FakeBuildContext());
     initializeTestDependencies();
     disableProviderDebugChecks();
   });
 
   setUp(() {
-    discoveredDevices = ValueNotifier([]);
     bleBloc = MockBleBloc();
-    when(() => bleBloc.discoveredDevicesNotifier).thenReturn(discoveredDevices);
-    when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(false));
-    when(() => bleBloc.isConnectingNotifier)
-        .thenReturn(ValueNotifier(false));
+  });
+
+  tearDown(() {
+    bleBloc.dispose();
   });
 
   testWidgets('shows dialog title', (tester) async {
@@ -51,16 +52,15 @@ void main() {
   });
 
   testWidgets('shows scan error', (tester) async {
-
     await tester.pumpWidget(
       createLocalizedTestApp(
         locale: const Locale('en'),
         child: Material(
           child: DeviceSelectionSheet(
-          bleBloc: bleBloc,
-          initialScanError: 'Test error',
+            bleBloc: bleBloc,
+            initialScanError: 'Test error',
+          ),
         ),
-        )
       ),
     );
 
@@ -68,8 +68,8 @@ void main() {
   });
 
   testWidgets('shows loading spinner while scanning', (tester) async {
-    when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(true));
-    
+    bleBloc.isScanningNotifier.value = true;
+
     await tester.pumpWidget(
       createLocalizedTestApp(
         locale: const Locale('en'),
@@ -84,8 +84,6 @@ void main() {
   });
 
   testWidgets('shows no devices found message', (tester) async {
-    when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(false));
-    
     await tester.pumpWidget(
       createLocalizedTestApp(
         locale: const Locale('en'),
@@ -102,8 +100,8 @@ void main() {
   testWidgets('shows list of devices and taps to connect', (tester) async {
     final device = MockBluetoothDevice();
     when(() => device.platformName).thenReturn('TestDevice');
-    discoveredDevices.value = [device];
-    bool connectCalled = false;
+    bleBloc.discoveredDevicesNotifier.value = [device];
+    var connectCalled = false;
     when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
       connectCalled = true;
       return BleConnectionResult.fullSuccess();
@@ -122,16 +120,44 @@ void main() {
     expect(find.text('TestDevice'), findsOneWidget);
 
     await tapElement(find.text('TestDevice'), tester);
-    await tester.pumpAndSettle();
     expect(connectCalled, isTrue);
+  });
+
+  testWidgets('shows connecting spinner while connect is pending',
+      (tester) async {
+    final device = MockBluetoothDevice();
+    when(() => device.platformName).thenReturn('TestDevice');
+    bleBloc.discoveredDevicesNotifier.value = [device];
+
+    final connectCompleter = Completer<BleConnectionResult>();
+    when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
+      return connectCompleter.future;
+    });
+
+    await tester.pumpWidget(
+      createLocalizedTestApp(
+        locale: const Locale('en'),
+        child: Material(
+          child: DeviceSelectionSheet(bleBloc: bleBloc),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.tap(find.text('TestDevice'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    connectCompleter.complete(BleConnectionResult.fullSuccess());
+    await tester.pumpAndSettle();
   });
 
   testWidgets('shows connection attempt failed dialog on failed connect',
       (tester) async {
     final device = MockBluetoothDevice();
     when(() => device.platformName).thenReturn('TestDevice');
-    when(() => bleBloc.startScanning()).thenAnswer((_) async {});
-    discoveredDevices.value = [device];
+    bleBloc.discoveredDevicesNotifier.value = [device];
     when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
       return BleConnectionResult.failure(
         reason: BleConnectionFailureReason.connectionTimeout,
@@ -160,7 +186,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Connection attempt failed'), findsOneWidget);
-    expect(find.textContaining('Turn the senseBox off and on'), findsOneWidget);
-    expect(find.textContaining('battery is charged'), findsOneWidget);
+    expect(
+      find.textContaining('could not connect to the senseBox in time'),
+      findsOneWidget,
+    );
   });
 }

--- a/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
+++ b/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
@@ -13,6 +13,7 @@ class FakeBuildContext extends Fake implements BuildContext {}
 
 void main() {
   late MockBleBloc bleBloc;
+  late ValueNotifier<List<BluetoothDevice>> discoveredDevices;
 
   setUpAll(() {
     registerFallbackValue(MockBluetoothDevice());
@@ -22,8 +23,9 @@ void main() {
   });
 
   setUp(() {
+    discoveredDevices = ValueNotifier([]);
     bleBloc = MockBleBloc();
-    when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([]));
+    when(() => bleBloc.discoveredDevicesNotifier).thenReturn(discoveredDevices);
     when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(false));
     when(() => bleBloc.isConnectingNotifier)
         .thenReturn(ValueNotifier(false));
@@ -67,7 +69,6 @@ void main() {
 
   testWidgets('shows loading spinner while scanning', (tester) async {
     when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(true));
-    when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([]));
     
     await tester.pumpWidget(
       createLocalizedTestApp(
@@ -84,7 +85,6 @@ void main() {
 
   testWidgets('shows no devices found message', (tester) async {
     when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(false));
-    when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([]));
     
     await tester.pumpWidget(
       createLocalizedTestApp(
@@ -96,13 +96,13 @@ void main() {
     );
 
     await tester.pump();
-    expect(find.textContaining('No senseBoxes found'), findsOneWidget); // Adjust to your localization
+    expect(find.textContaining('No senseBoxes found'), findsOneWidget);
   });
 
   testWidgets('shows list of devices and taps to connect', (tester) async {
     final device = MockBluetoothDevice();
     when(() => device.platformName).thenReturn('TestDevice');
-    when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([device]));
+    discoveredDevices.value = [device];
     bool connectCalled = false;
     when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
       connectCalled = true;
@@ -131,7 +131,7 @@ void main() {
     final device = MockBluetoothDevice();
     when(() => device.platformName).thenReturn('TestDevice');
     when(() => bleBloc.startScanning()).thenAnswer((_) async {});
-    when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([device]));
+    discoveredDevices.value = [device];
     when(() => bleBloc.connectToDevice(device)).thenAnswer((_) async {
       return BleConnectionResult.failure(
         reason: BleConnectionFailureReason.connectionTimeout,

--- a/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
+++ b/test/ui/widgets/home/ble_device_selection_dialog_widget_test.dart
@@ -27,8 +27,6 @@ void main() {
     when(() => bleBloc.isScanningNotifier).thenReturn(ValueNotifier(false));
     when(() => bleBloc.isConnectingNotifier)
         .thenReturn(ValueNotifier(false));
-    when(() => bleBloc.finalizePartialConnection(any(), any()))
-        .thenAnswer((_) async => BleConnectionResult.fullSuccess());
   });
 
   testWidgets('shows dialog title', (tester) async {
@@ -126,54 +124,6 @@ void main() {
     await tapElement(find.text('TestDevice'), tester);
     await tester.pumpAndSettle();
     expect(connectCalled, isTrue);
-  });
-
-  testWidgets('shows partial connection dialog when some sensors fail',
-      (tester) async {
-    final device = MockBluetoothDevice();
-    when(() => device.platformName).thenReturn('TestDevice');
-    when(() => bleBloc.startScanning()).thenAnswer((_) async {});
-    when(() => bleBloc.devicesListStream).thenAnswer((_) => Stream.value([device]));
-    when(() => bleBloc.connectToDevice(device, any())).thenAnswer((_) async {
-      return BleConnectionResult.needsUserDecision(probes: [
-        const BleCharacteristicProbeResult(
-          uuid: '2cdf2174-35be-fdc4-4ca2-6fd173f8b3a8',
-          isValid: true,
-        ),
-        const BleCharacteristicProbeResult(
-          uuid: 'unknown-sensor-uuid',
-          isValid: false,
-          reason: BleConnectionFailureReason.noData,
-        ),
-      ]);
-    });
-
-    await tester.pumpWidget(
-      createLocalizedTestApp(
-        locale: const Locale('en'),
-        child: Builder(
-          builder: (context) {
-            return ElevatedButton(
-              onPressed: () => showDeviceSelectionDialog(context, bleBloc),
-              child: const Text('Open'),
-            );
-          },
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('Open'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
-
-    expect(find.text('TestDevice'), findsOneWidget);
-
-    await tester.tap(find.text('TestDevice'));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Some sensors unavailable'), findsOneWidget);
-    expect(find.text('Continue'), findsOneWidget);
-    expect(find.text('Cancel'), findsOneWidget);
   });
 
   testWidgets('shows connection attempt failed dialog on failed connect',


### PR DESCRIPTION
## Summary
- Replace `isConnecting`/`isReconnecting` notifiers with `BleConnectionPhase`
- Remove `BuildContext`/`ChangeNotifier` from BleBloc
- Explicit idle phase after failed reconnection
- Expanded BLE bloc and dialog tests
Depends on: iOS Always location PR (for AppDialog)
## Test plan
- [ ] Connect/disconnect BLE device
- [ ] Reconnection after signal loss
- [ ] Connection failure dialogs show correct messages
