### PR TITLE
refactor: simplify blocs and move recording UI to callbacks

### DIFF
--- a/lib/blocs/geolocation_bloc.dart
+++ b/lib/blocs/geolocation_bloc.dart
@@ -1,20 +1,20 @@
-// File: lib/blocs/geolocation_bloc.dart
 import 'dart:async';
-import 'package:flutter/material.dart';
+
 import 'package:flutter/foundation.dart';
-import 'package:sensebox_bike/blocs/recording_bloc.dart';
+import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:sensebox_bike/blocs/recording_bloc.dart';
 import 'package:sensebox_bike/blocs/settings_bloc.dart';
 import 'package:sensebox_bike/models/geolocation_data.dart';
 import 'package:sensebox_bike/services/custom_exceptions.dart';
 import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/services/permission_service.dart';
-import 'package:sensebox_bike/utils/sensor_utils.dart';
-import 'package:sensebox_bike/utils/privacy_zone_checker.dart';
 import 'package:sensebox_bike/utils/geolocation_utils.dart';
+import 'package:sensebox_bike/utils/privacy_zone_checker.dart';
+import 'package:sensebox_bike/utils/sensor_utils.dart';
 
-class GeolocationBloc with ChangeNotifier {
+class GeolocationBloc {
   final StreamController<GeolocationData> _geolocationController =
       StreamController.broadcast();
   Stream<GeolocationData> get geolocationStream =>
@@ -25,23 +25,31 @@ class GeolocationBloc with ChangeNotifier {
   GeolocationData? _lastEmittedPosition;
   Timer? _stationaryLocationTimer;
   final PrivacyZoneChecker _privacyZoneChecker = PrivacyZoneChecker();
-  bool _isListening = false;
+  late final VoidCallback _recordingListener;
 
-  bool get isListening => _isListening;
+  bool get isListening => _positionStreamSubscription != null;
 
   final IsarService isarService;
   final RecordingBloc recordingBloc;
-  final SettingsBloc settingsBloc;
 
-  GeolocationBloc(this.isarService, this.recordingBloc, this.settingsBloc) {
+  GeolocationBloc(this.isarService, this.recordingBloc, SettingsBloc settingsBloc) {
     _privacyZoneChecker.updatePrivacyZones(settingsBloc.privacyZones);
-    _privacyZonesSubscription = settingsBloc.privacyZonesStream.listen((zones) {
-      _privacyZoneChecker.updatePrivacyZones(zones);
-    });
+    _privacyZonesSubscription = settingsBloc.privacyZonesStream.listen(
+      _privacyZoneChecker.updatePrivacyZones,
+    );
+
+    _recordingListener = () {
+      if (recordingBloc.isRecording) {
+        _startStationaryLocationTimer();
+      } else {
+        _stopStationaryLocationTimer();
+      }
+    };
+    recordingBloc.isRecordingNotifier.addListener(_recordingListener);
   }
 
   Future<void> startListening() async {
-    if (_isListening) {
+    if (isListening) {
       return;
     }
 
@@ -49,102 +57,78 @@ class GeolocationBloc with ChangeNotifier {
       await PermissionService.ensureLocationPermissionsGranted();
       await PermissionService.ensureNotificationPermissionGranted();
 
-      late LocationSettings locationSettings;
+      final locationSettings = await _buildLocationSettings();
 
-      if (defaultTargetPlatform == TargetPlatform.android) {
-        locationSettings = AndroidSettings(
-            accuracy: LocationAccuracy.bestForNavigation,
-            distanceFilter: 0,
-            foregroundNotificationConfig: const ForegroundNotificationConfig(
-                notificationText:
-                    "senseBox:bike will record your location in the background",
-                notificationTitle: "Running in the background",
-                enableWakeLock: true,
-                notificationIcon: AndroidResource(
-                    name: "@mipmap/ic_stat_sensebox_bike_logo"),
-                color: Colors.blue));
-      } else if (defaultTargetPlatform == TargetPlatform.iOS ||
-          defaultTargetPlatform == TargetPlatform.macOS) {
-        final allowBackground =
-            await PermissionService.allowsBackgroundLocation();
-        locationSettings = AppleSettings(
-          accuracy: LocationAccuracy.bestForNavigation,
-          distanceFilter: 0,
-          activityType: ActivityType.fitness,
-          pauseLocationUpdatesAutomatically: false,
-          showBackgroundLocationIndicator: allowBackground,
-          allowBackgroundLocationUpdates: allowBackground,
-        );
-      } else {
-        locationSettings = const LocationSettings(
-          accuracy: LocationAccuracy.bestForNavigation,
-          distanceFilter: 0,
-        );
-      }
-
-      await _positionStreamSubscription?.cancel();
       _positionStreamSubscription =
           Geolocator.getPositionStream(locationSettings: locationSettings)
               .listen(
-        (Position position) async {
-          final geolocationData = _createGeolocationFromPosition(position);
-
-          if (shouldSkipGeolocation(geolocationData)) {
-            return;
-          }
-
-          _lastEmittedPosition = geolocationData;
-          _resetStationaryLocationTimer();
-
-          final shouldEmit = await _saveGeolocationIfRecording(geolocationData);
-          if (shouldEmit) {
-            _emitGeolocation(geolocationData);
-          }
+        (position) async {
+          await _processGeolocation(_geolocationFromPosition(position));
         },
         onError: _handlePositionStreamError,
       );
 
-      _startStationaryLocationTimer();
-      _isListening = true;
+      if (recordingBloc.isRecording) {
+        _startStationaryLocationTimer();
+      }
     } catch (e, stack) {
-      _positionStreamSubscription?.cancel();
-      _positionStreamSubscription = null;
-      _stopStationaryLocationTimer();
-      _isListening = false;
+      _resetListeningState();
       ErrorService.logToConsole(e, stack);
       rethrow;
     }
   }
 
+  Future<LocationSettings> _buildLocationSettings() async {
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return AndroidSettings(
+        accuracy: LocationAccuracy.bestForNavigation,
+        distanceFilter: 0,
+        foregroundNotificationConfig: const ForegroundNotificationConfig(
+          notificationText:
+              'senseBox:bike will record your location in the background',
+          notificationTitle: 'Running in the background',
+          enableWakeLock: true,
+          notificationIcon:
+              AndroidResource(name: '@mipmap/ic_stat_sensebox_bike_logo'),
+          color: Colors.blue,
+        ),
+      );
+    }
+
+    if (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS) {
+      final allowBackground =
+          await PermissionService.allowsBackgroundLocation();
+      return AppleSettings(
+        accuracy: LocationAccuracy.bestForNavigation,
+        distanceFilter: 0,
+        activityType: ActivityType.fitness,
+        pauseLocationUpdatesAutomatically: false,
+        showBackgroundLocationIndicator: allowBackground,
+        allowBackgroundLocationUpdates: allowBackground,
+      );
+    }
+
+    return const LocationSettings(
+      accuracy: LocationAccuracy.bestForNavigation,
+      distanceFilter: 0,
+    );
+  }
+
   void _handlePositionStreamError(Object error, StackTrace stack) {
-    _positionStreamSubscription?.cancel();
-    _positionStreamSubscription = null;
-    _stopStationaryLocationTimer();
-    _isListening = false;
+    _resetListeningState();
     ErrorService.handleError(GeolocationStartFailed(error), stack);
   }
 
-  // function to get the current location
   Future<Position> getCurrentLocation() async {
     await PermissionService.ensureLocationPermissionsGranted();
-
     return Geolocator.getCurrentPosition();
   }
 
   Future<void> getCurrentLocationAndEmit() async {
     try {
       final position = await getCurrentLocation();
-      final geolocationData = _createGeolocationFromPosition(position);
-
-      if (shouldSkipGeolocation(geolocationData)) {
-        return;
-      }
-
-      _lastEmittedPosition = geolocationData;
-      final shouldEmit = await _saveGeolocationIfRecording(geolocationData);
-      if (shouldEmit) {
-        _emitGeolocation(geolocationData);
-      }
+      await _processGeolocation(_geolocationFromPosition(position));
     } catch (e, stack) {
       ErrorService.handleError(e, stack);
     }
@@ -152,60 +136,48 @@ class GeolocationBloc with ChangeNotifier {
 
   void _startStationaryLocationTimer() {
     _stopStationaryLocationTimer();
-    
+
     if (!recordingBloc.isRecording) {
       return;
     }
-    
-    _stationaryLocationTimer = Timer.periodic(const Duration(seconds: 20), (timer) async {
+
+    _stationaryLocationTimer =
+        Timer.periodic(const Duration(seconds: 20), (timer) async {
       if (!recordingBloc.isRecording) {
         _stopStationaryLocationTimer();
         return;
       }
-      
+
       if (_lastEmittedPosition != null) {
-        final geolocationData = GeolocationData()
-          ..latitude = _lastEmittedPosition!.latitude
-          ..longitude = _lastEmittedPosition!.longitude
-          ..speed = _lastEmittedPosition!.speed
-          ..timestamp = DateTime.now().toUtc();
-
-        if (shouldSkipGeolocation(geolocationData)) {
-          return;
-        }
-
-        final shouldEmit = await _saveGeolocationIfRecording(geolocationData);
-        if (shouldEmit) {
-          _emitGeolocation(geolocationData);
-        }
+        await _processGeolocation(
+          _copyGeolocation(
+            _lastEmittedPosition!,
+            timestamp: DateTime.now().toUtc(),
+          ),
+        );
       } else {
-        try {
-          await getCurrentLocationAndEmit();
-        } catch (e, stack) {
-          ErrorService.handleError(e, stack);
-        }
+        await getCurrentLocationAndEmit();
       }
     });
   }
-  
-  void _resetStationaryLocationTimer() {
-    _startStationaryLocationTimer();
-  }
-  
+
   void _stopStationaryLocationTimer() {
     _stationaryLocationTimer?.cancel();
     _stationaryLocationTimer = null;
   }
 
-  // function to stop listening to geolocation changes
   void stopListening() {
-    _positionStreamSubscription?.cancel();
-    _stopStationaryLocationTimer();
+    _resetListeningState();
     _lastEmittedPosition = null;
-    _isListening = false;
   }
 
-  GeolocationData _createGeolocationFromPosition(Position position) {
+  void _resetListeningState() {
+    _positionStreamSubscription?.cancel();
+    _positionStreamSubscription = null;
+    _stopStationaryLocationTimer();
+  }
+
+  GeolocationData _geolocationFromPosition(Position position) {
     return GeolocationData()
       ..latitude = position.latitude
       ..longitude = position.longitude
@@ -215,31 +187,50 @@ class GeolocationBloc with ChangeNotifier {
           : position.timestamp.toUtc();
   }
 
-  bool shouldSkipGeolocation(GeolocationData geolocationData,
-      {GeolocationData? lastEmittedPosition}) {
+  GeolocationData _copyGeolocation(
+    GeolocationData source, {
+    required DateTime timestamp,
+  }) {
+    return GeolocationData()
+      ..latitude = source.latitude
+      ..longitude = source.longitude
+      ..speed = source.speed
+      ..timestamp = timestamp;
+  }
+
+  Future<void> _processGeolocation(GeolocationData geolocationData) async {
+    if (shouldSkipGeolocation(geolocationData)) {
+      return;
+    }
+
+    _lastEmittedPosition = geolocationData;
+
+    if (await _saveGeolocationIfRecording(geolocationData)) {
+      _geolocationController.add(geolocationData);
+    }
+  }
+
+  bool shouldSkipGeolocation(
+    GeolocationData geolocationData, {
+    GeolocationData? lastEmittedPosition,
+  }) {
     final lastPosition = lastEmittedPosition ?? _lastEmittedPosition;
 
     if (lastPosition == null) {
-      final inPrivacyZone =
-          _privacyZoneChecker.isInsidePrivacyZone(geolocationData);
-
-      return inPrivacyZone;
+      return _privacyZoneChecker.isInsidePrivacyZone(geolocationData);
     }
 
     if (shouldSkipGeolocationByTime(geolocationData, lastPosition)) {
       return true;
     }
 
-    if (_privacyZoneChecker.isInsidePrivacyZone(geolocationData)) {
-      return true;
-    }
-
-    return false;
+    return _privacyZoneChecker.isInsidePrivacyZone(geolocationData);
   }
 
   Future<bool> _saveGeolocationIfRecording(
-      GeolocationData geolocationData,
-      {bool allowFinalGeolocation = false}) async {
+    GeolocationData geolocationData, {
+    bool allowFinalGeolocation = false,
+  }) async {
     if ((!recordingBloc.isRecording && !allowFinalGeolocation) ||
         recordingBloc.currentTrack == null) {
       return false;
@@ -260,7 +251,7 @@ class GeolocationBloc with ChangeNotifier {
           ErrorService.handleError(e, stack);
         }
       }
-      
+
       return true;
     } catch (e) {
       geolocationData.id = 0;
@@ -268,50 +259,41 @@ class GeolocationBloc with ChangeNotifier {
     }
   }
 
-  void _emitGeolocation(GeolocationData geolocationData) {
-    _geolocationController.add(geolocationData);
-    notifyListeners();
-  }
-
   Future<void> emitFinalGeolocation() async {
-    if (_lastEmittedPosition == null || recordingBloc.currentTrack == null) {
+    final lastPosition = _lastEmittedPosition;
+    if (lastPosition == null || recordingBloc.currentTrack == null) {
       return;
     }
 
     final stopTimestamp =
         recordingBloc.lastRecordingStopTimestamp ?? DateTime.now().toUtc();
 
-    final finalGeolocation = GeolocationData()
-      ..latitude = _lastEmittedPosition!.latitude
-      ..longitude = _lastEmittedPosition!.longitude
-      ..speed = _lastEmittedPosition!.speed
-      ..timestamp = stopTimestamp;
-
-    final lastTimestamp =
-        _lastEmittedPosition!.timestamp.millisecondsSinceEpoch;
-    final stopTimestampMs = stopTimestamp.millisecondsSinceEpoch;
-
-    if (lastTimestamp == stopTimestampMs) {
+    if (lastPosition.timestamp.millisecondsSinceEpoch ==
+        stopTimestamp.millisecondsSinceEpoch) {
       return;
     }
+
+    final finalGeolocation =
+        _copyGeolocation(lastPosition, timestamp: stopTimestamp);
 
     if (_privacyZoneChecker.isInsidePrivacyZone(finalGeolocation)) {
       return;
     }
 
-    final shouldEmit = await _saveGeolocationIfRecording(finalGeolocation,
-        allowFinalGeolocation: true);
-    if (shouldEmit) {
-      _emitGeolocation(finalGeolocation);
+    if (await _saveGeolocationIfRecording(
+      finalGeolocation,
+      allowFinalGeolocation: true,
+    )) {
+      _geolocationController.add(finalGeolocation);
       _lastEmittedPosition = finalGeolocation;
     }
   }
 
-  @override
   void dispose() {
+    recordingBloc.isRecordingNotifier.removeListener(_recordingListener);
     _privacyZonesSubscription?.cancel();
+    stopListening();
     _privacyZoneChecker.dispose();
     _geolocationController.close();
-    super.dispose();
   }
 }

--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -1,79 +1,66 @@
-import 'package:flutter/material.dart';
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
 import 'package:sensebox_bike/blocs/settings_bloc.dart';
 import 'package:sensebox_bike/blocs/track_bloc.dart';
 import 'package:sensebox_bike/models/sensebox.dart';
 import 'package:sensebox_bike/models/track_data.dart';
+import 'package:sensebox_bike/services/batch_upload_service.dart';
 import 'package:sensebox_bike/services/custom_exceptions.dart';
+import 'package:sensebox_bike/services/direct_upload_service.dart';
 import 'package:sensebox_bike/services/error_service.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
-import 'package:sensebox_bike/services/direct_upload_service.dart';
 import 'package:sensebox_bike/services/opensensemap_service.dart';
-import 'package:sensebox_bike/services/batch_upload_service.dart';
-import 'package:sensebox_bike/ui/widgets/common/upload_progress_modal.dart';
-import 'package:sensebox_bike/ui/widgets/home/ble_connection_dialogs.dart';
 import 'package:sensebox_bike/services/permission_service.dart';
+import 'package:sensebox_bike/ui/widgets/common/upload_progress_modal.dart';
 
-class RecordingBloc with ChangeNotifier {
+typedef BatchUploadPromptHandler = Future<void> Function({
+  required TrackData track,
+  required SenseBox? senseBox,
+  required BatchUploadService batchUploadService,
+  required VoidCallback onFinished,
+});
+
+class RecordingBloc {
   final BleBloc bleBloc;
   final IsarService isarService;
   final TrackBloc trackBloc;
   final OpenSenseMapBloc openSenseMapBloc;
   final SettingsBloc settingsBloc;
 
-  bool _isRecording = false;
   TrackData? _currentTrack;
-  SenseBox? _selectedSenseBox;
-  final ValueNotifier<bool> _isRecordingNotifier = ValueNotifier<bool>(false);
   DirectUploadService? _directUploadService;
   BatchUploadService? _batchUploadService;
 
   VoidCallback? _onRecordingStop;
   Future<void> Function()? _onRecordingStartAsync;
+  Future<void> Function()? _onRecordingStoppedDueToBle;
+  BatchUploadPromptHandler? _onBatchUploadPrompt;
 
-  // Context for showing upload modal
-  BuildContext? _context;
   DateTime? _lastRecordingStopTimestamp;
 
-  bool get isRecording => _isRecording;
+  final ValueNotifier<bool> isRecordingNotifier = ValueNotifier(false);
 
-  ValueNotifier<bool> get isRecordingNotifier => _isRecordingNotifier;
+  bool get isRecording => isRecordingNotifier.value;
+  bool get _directUploadMode => settingsBloc.directUploadMode;
 
   TrackData? get currentTrack => _currentTrack;
-  SenseBox? get selectedSenseBox => _selectedSenseBox;
   DateTime? get lastRecordingStopTimestamp => _lastRecordingStopTimestamp;
 
-  RecordingBloc(this.isarService, this.bleBloc, this.trackBloc,
-      this.openSenseMapBloc, this.settingsBloc) {
-    openSenseMapBloc.senseBoxStream.listen(_onSenseBoxChanged).onError((error) {
-      ErrorService.handleError(error, StackTrace.current);
-    });
+  DirectUploadService? get directUploadService => _directUploadService;
+  BatchUploadService? get batchUploadService => _batchUploadService;
 
-    // Listen to BLE connection errors and stop recording
+  RecordingBloc(
+    this.isarService,
+    this.bleBloc,
+    this.trackBloc,
+    this.openSenseMapBloc,
+    this.settingsBloc,
+  ) {
     bleBloc.connectionErrorNotifier.addListener(_onBleConnectionError);
   }
-
-  void _onBleConnectionError() {
-    if (!bleBloc.connectionErrorNotifier.value || !_isRecording) {
-      return;
-    }
-
-    stopRecording(dueToBleDisconnect: true);
-  }
-
-  void _onDirectUploadFailed() {
-    if (_currentTrack != null) {
-      trackBloc.updateDirectUploadAuthFailure(_currentTrack!);
-      ErrorService.handleError(
-        DirectUploadFailureError(),
-        StackTrace.current,
-        sendToSentry: false,
-      );
-    }
-  }
-
-
 
   void setRecordingCallbacks({
     Future<void> Function()? onRecordingStart,
@@ -83,25 +70,29 @@ class RecordingBloc with ChangeNotifier {
     _onRecordingStop = onRecordingStop;
   }
 
-  /// Sets the context for showing upload modals
-  void setContext(BuildContext context) {
-    _context = context;
+  void setUiCallbacks({
+    Future<void> Function()? onRecordingStoppedDueToBle,
+    BatchUploadPromptHandler? onBatchUploadPrompt,
+  }) {
+    _onRecordingStoppedDueToBle = onRecordingStoppedDueToBle;
+    _onBatchUploadPrompt = onBatchUploadPrompt;
   }
 
-  void _onSenseBoxChanged(SenseBox? senseBox) {
-    _selectedSenseBox = senseBox;
-    notifyListeners();
+  void clearUiCallbacks() {
+    _onRecordingStoppedDueToBle = null;
+    _onBatchUploadPrompt = null;
   }
 
   Future<void> startRecording() async {
-    if (_isRecording) return;
+    if (isRecording) {
+      return;
+    }
 
     try {
       await PermissionService.ensureLocationPermissionsForRecording();
       await PermissionService.ensureNotificationPermissionGranted();
     } catch (e, stack) {
       ErrorService.handleError(e, stack);
-      notifyListeners();
       return;
     }
 
@@ -111,7 +102,6 @@ class RecordingBloc with ChangeNotifier {
         StackTrace.current,
         sendToSentry: false,
       );
-      notifyListeners();
       return;
     }
 
@@ -120,40 +110,24 @@ class RecordingBloc with ChangeNotifier {
     int? trackId;
 
     try {
-      trackId = await trackBloc.startNewTrack(
-        isDirectUpload: settingsBloc.directUploadMode,
-      );
+      trackId = await trackBloc.startNewTrack(isDirectUpload: _directUploadMode);
       _currentTrack = trackBloc.currentTrack;
 
-      if (_selectedSenseBox == null && settingsBloc.directUploadMode) {
+      if (_directUploadMode && openSenseMapBloc.selectedSenseBox == null) {
         await trackBloc.updateDirectUploadAuthFailure(_currentTrack!);
         throw NoSenseBoxSelected();
       }
 
-      if (settingsBloc.directUploadMode) {
-        directUploadService = DirectUploadService(
-          openSenseMapService: OpenSenseMapService(),
-          senseBox: _selectedSenseBox!,
-          openSenseMapBloc: openSenseMapBloc,
-          onUploadFailed: _onDirectUploadFailed,
-        );
-      } else {
-        batchUploadService = BatchUploadService(
-          openSenseMapService: openSenseMapBloc.openSenseMapService,
-          trackService: isarService.trackService,
-          openSenseMapBloc: openSenseMapBloc,
-        );
-      }
+      final uploadServices = _createUploadServices();
+      directUploadService = uploadServices.directUploadService;
+      batchUploadService = uploadServices.batchUploadService;
 
-      _isRecording = true;
-      _isRecordingNotifier.value = true;
+      isRecordingNotifier.value = true;
       _lastRecordingStopTimestamp = null;
       _directUploadService = directUploadService;
       _batchUploadService = batchUploadService;
 
-      if (_onRecordingStartAsync != null) {
-        await _onRecordingStartAsync!();
-      }
+      await _onRecordingStartAsync?.call();
     } catch (e, stack) {
       await _rollbackRecordingStart(
         trackId: trackId ?? _currentTrack?.id,
@@ -167,8 +141,101 @@ class RecordingBloc with ChangeNotifier {
         sendToSentry: e is! NoSenseBoxSelected,
       );
     }
+  }
 
-    notifyListeners();
+  Future<void> stopRecording({bool dueToBleDisconnect = false}) async {
+    if (!isRecording) {
+      return;
+    }
+
+    _lastRecordingStopTimestamp = DateTime.now().toUtc();
+    isRecordingNotifier.value = false;
+    _onRecordingStop?.call();
+
+    final trackToUpload = _currentTrack;
+    final senseBoxForUpload = openSenseMapBloc.selectedSenseBox;
+    final batchUploadService = _batchUploadService;
+
+    _disposeDirectUploadService();
+    _currentTrack = null;
+    _batchUploadService = null;
+
+    final shouldPromptBatchUpload = !_directUploadMode &&
+        batchUploadService != null &&
+        trackToUpload != null &&
+        _onBatchUploadPrompt != null;
+
+    if (!shouldPromptBatchUpload) {
+      batchUploadService?.dispose();
+    }
+
+    if (dueToBleDisconnect) {
+      await _onRecordingStoppedDueToBle?.call();
+    }
+
+    if (shouldPromptBatchUpload) {
+      await _onBatchUploadPrompt!(
+        track: trackToUpload,
+        senseBox: senseBoxForUpload,
+        batchUploadService: batchUploadService!,
+        onFinished: () {},
+      );
+    }
+  }
+
+  void dispose() {
+    bleBloc.connectionErrorNotifier.removeListener(_onBleConnectionError);
+    clearUiCallbacks();
+    _disposeDirectUploadService();
+    _disposeBatchUploadService();
+    isRecordingNotifier.dispose();
+    UploadProgressOverlay.hide();
+  }
+
+  void _onBleConnectionError() {
+    if (bleBloc.connectionErrorNotifier.value && isRecording) {
+      stopRecording(dueToBleDisconnect: true);
+    }
+  }
+
+  void _onDirectUploadFailed() {
+    final track = _currentTrack;
+    if (track == null) {
+      return;
+    }
+
+    trackBloc.updateDirectUploadAuthFailure(track);
+    ErrorService.handleError(
+      DirectUploadFailureError(),
+      StackTrace.current,
+      sendToSentry: false,
+    );
+  }
+
+  ({
+    DirectUploadService? directUploadService,
+    BatchUploadService? batchUploadService,
+  }) _createUploadServices() {
+    if (_directUploadMode) {
+      return (
+        directUploadService: DirectUploadService(
+          openSenseMapService: OpenSenseMapService(),
+          senseBox: openSenseMapBloc.selectedSenseBox!,
+          openSenseMapBloc: openSenseMapBloc,
+          onUploadFailed: _onDirectUploadFailed,
+        ),
+        batchUploadService: null,
+      );
+    }
+
+    return (
+      directUploadService: null,
+      batchUploadService: BatchUploadService(
+        openSenseMapService: openSenseMapBloc.openSenseMapService,
+        trackService: isarService.trackService,
+        openSenseMapBloc: openSenseMapBloc,
+      ),
+    );
   }
 
   Future<void> _rollbackRecordingStart({
@@ -176,8 +243,7 @@ class RecordingBloc with ChangeNotifier {
     DirectUploadService? directUploadService,
     BatchUploadService? batchUploadService,
   }) async {
-    _isRecording = false;
-    _isRecordingNotifier.value = false;
+    isRecordingNotifier.value = false;
     _lastRecordingStopTimestamp = null;
 
     directUploadService?.dispose();
@@ -194,127 +260,13 @@ class RecordingBloc with ChangeNotifier {
     trackBloc.endTrack();
   }
 
-  Future<void> stopRecording({bool dueToBleDisconnect = false}) async {
-    if (!_isRecording) return;
-
-    _lastRecordingStopTimestamp = DateTime.now().toUtc();
-
-    _isRecording = false;
-    _isRecordingNotifier.value = false;
-    _onRecordingStop?.call();
-
-    // Store current track and sensebox for upload
-    final trackToUpload = _currentTrack;
-    final senseBoxForUpload = _selectedSenseBox;
-
-    // Clean up services and handle post-ride upload if needed
+  void _disposeDirectUploadService() {
     _directUploadService?.dispose();
     _directUploadService = null;
-    _currentTrack = null;
-
-    final shouldShowUploadModal = !settingsBloc.directUploadMode &&
-        _batchUploadService != null &&
-        trackToUpload != null &&
-        _context != null;
-
-    if (!shouldShowUploadModal) {
-      _batchUploadService?.dispose();
-      _batchUploadService = null;
-    }
-
-    notifyListeners();
-
-    if (dueToBleDisconnect) {
-      await _showRecordingStoppedDueToBleDialog();
-    }
-
-    if (shouldShowUploadModal && (_context?.mounted ?? false)) {
-      _showUploadProgressModal(trackToUpload, senseBoxForUpload);
-    }
   }
 
-  Future<void> _showRecordingStoppedDueToBleDialog() async {
-    final context = _context;
-    if (context == null || !context.mounted) {
-      return;
-    }
-
-    await showRecordingStoppedDueToBleDialog(context);
-  }
-
-  void _showUploadProgressModal(TrackData track, SenseBox? senseBox) async {
-    if (_context == null || _batchUploadService == null) return;
-
-    final canUpload =
-        senseBox != null && openSenseMapBloc.hasAuthAndSelectedSenseBox;
-
-    try {
-      await track.geolocations.load();
-      final geolocations = track.geolocations.toList();
-
-      if (geolocations.isEmpty) {
-        throw TrackHasNoGeolocationsException(track.id);
-      }
-
-      UploadProgressOverlay.show(
-        _context!,
-        batchUploadService: _batchUploadService!,
-        canUpload: canUpload,
-        isAuthenticated: openSenseMapBloc.isAuthenticated,
-        hasSelectedBox: openSenseMapBloc.selectedSenseBox != null,
-        onUploadComplete: () {
-          _cleanupBatchUploadService();
-          debugPrint('[RecordingBloc] Batch upload completed successfully');
-        },
-        onUploadFailed: () {
-          _cleanupBatchUploadService();
-          debugPrint('[RecordingBloc] Batch upload failed permanently');
-        },
-        onStartUpload: () {
-          if (canUpload) _startBatchUpload(track, senseBox!);
-        },
-      );
-    } catch (e, stack) {
-      debugPrint('[RecordingBloc] Error showing upload modal: $e');
-      ErrorService.handleError(e, stack);
-      UploadProgressOverlay.hide();
-      _cleanupBatchUploadService();
-    }
-  }
-
-  void _startBatchUpload(TrackData track, SenseBox senseBox) async {
-    if (_batchUploadService == null) return;
-
-    try {
-      await _batchUploadService!.uploadTrack(track, senseBox);
-    } catch (e, stack) {
-      // Log error but don't prevent recording from stopping
-      // The modal will show the error state and allow retry
-      ErrorService.handleError(
-        'Batch upload failed after recording stop: $e',
-        stack,
-        sendToSentry: true,
-      );
-    }
-  }
-  void _cleanupBatchUploadService() {
+  void _disposeBatchUploadService() {
     _batchUploadService?.dispose();
     _batchUploadService = null;
-  }
-
-  DirectUploadService? get directUploadService => _directUploadService;
-  BatchUploadService? get batchUploadService => _batchUploadService;
-
-  @override
-  void dispose() {
-    bleBloc.connectionErrorNotifier.removeListener(_onBleConnectionError);
-    _directUploadService?.dispose();
-    _batchUploadService?.dispose();
-    _isRecordingNotifier.dispose();
-
-    // Hide any open upload modal
-    UploadProgressOverlay.hide();
-
-    super.dispose();
   }
 }

--- a/lib/blocs/sensor_bloc.dart
+++ b/lib/blocs/sensor_bloc.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:sensebox_bike/blocs/ble_bloc.dart';
 import 'package:sensebox_bike/blocs/geolocation_bloc.dart';
 import 'package:sensebox_bike/blocs/recording_bloc.dart';
-import 'package:sensebox_bike/blocs/settings_bloc.dart';
 import 'package:sensebox_bike/feature_flags.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
 import 'package:sensebox_bike/sensors/acceleration_sensor.dart';
 import 'package:sensebox_bike/sensors/distance_sensor.dart';
 import 'package:sensebox_bike/sensors/distance_right_sensor.dart';
@@ -18,171 +19,139 @@ import 'package:sensebox_bike/sensors/sensor.dart';
 import 'package:sensebox_bike/sensors/surface_anomaly_sensor.dart';
 import 'package:sensebox_bike/sensors/surface_classification_sensor.dart';
 import 'package:sensebox_bike/sensors/temperature_sensor.dart';
+import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/services/sensor_csv_logger_service.dart';
 import 'package:sensebox_bike/services/error_service.dart';
 
-class SensorBloc with ChangeNotifier {
+typedef _SensorFactory = Sensor Function(
+  BleBloc bleBloc,
+  GeolocationBloc geolocationBloc,
+  RecordingBloc recordingBloc,
+  IsarService isarService,
+);
+
+class SensorBloc {
+  static const _sensorFactories = <_SensorFactory>[
+    TemperatureSensor.new,
+    HumiditySensor.new,
+    DistanceSensor.new,
+    DistanceRightSensor.new,
+    SurfaceClassificationSensor.new,
+    AccelerationSensor.new,
+    OvertakingPredictionSensor.new,
+    SurfaceAnomalySensor.new,
+    FinedustSensor.new,
+    GPSSensor.new,
+  ];
+
   final BleBloc bleBloc;
   final GeolocationBloc geolocationBloc;
   final RecordingBloc recordingBloc;
-  final SettingsBloc settingsBloc;
   final List<Sensor> _sensors = [];
-  late final VoidCallback _characteristicsListener;
-  late final VoidCallback _characteristicStreamsVersionListener;
-  late final VoidCallback _selectedDeviceListener;
-  late final VoidCallback _recordingListener;
-  List<String> _lastCharacteristicUuids = [];
+
+  late final VoidCallback _connectionPhaseListener;
   bool _isStartingListening = false;
 
-  SensorBloc(this.bleBloc, this.geolocationBloc, this.recordingBloc,
-      this.settingsBloc) {
-    _initializeSensors();
+  SensorBloc(this.bleBloc, this.geolocationBloc, this.recordingBloc) {
+    final isarService = geolocationBloc.isarService;
+    for (final factory in _sensorFactories) {
+      _sensors.add(factory(bleBloc, geolocationBloc, recordingBloc, isarService));
+    }
 
-    _selectedDeviceListener = () {
-      final device = bleBloc.selectedDeviceNotifier.value;
-      if (device != null && device.isConnected) {
-        _startListening();
-        if (!geolocationBloc.isListening) {
-          geolocationBloc.startListening().catchError((error, stackTrace) {
-            ErrorService.handleError(error, stackTrace);
-          });
-        }
-      } else {
-        _stopListening();
-        geolocationBloc.stopListening();
-      }
-      notifyListeners();
+    _connectionPhaseListener = () {
+      unawaited(_applyConnectionPhase(bleBloc.connectionPhaseNotifier.value));
     };
 
-    _characteristicsListener = () {
-      final currentUuids = bleBloc.availableCharacteristics.value
-          .map((e) => e.uuid.toString())
-          .toList();
-      if (!_listEqualsUnordered(_lastCharacteristicUuids, currentUuids)) {
-        _lastCharacteristicUuids = List.from(currentUuids);
-        _restartAllSensors();
-      }
-    };
-
-    _characteristicStreamsVersionListener = () {
-      _restartAllSensors();
-    };
-
-    _recordingListener = () {
-      if (!recordingBloc.isRecording) {
-        _flushAllSensorBuffers();
-      }
-    };
-    recordingBloc.isRecordingNotifier.addListener(_recordingListener);
     recordingBloc.setRecordingCallbacks(
       onRecordingStart: _onRecordingStart,
       onRecordingStop: _onRecordingStop,
     );
 
-    bleBloc.selectedDeviceNotifier.addListener(_selectedDeviceListener);
-    bleBloc.availableCharacteristics.addListener(_characteristicsListener);
-    bleBloc.characteristicStreamsVersion
-        .addListener(_characteristicStreamsVersionListener);
+    bleBloc.connectionPhaseNotifier.addListener(_connectionPhaseListener);
+    _connectionPhaseListener();
+  }
+
+  Set<String> get _availableCharacteristicUuids =>
+      bleBloc.availableCharacteristics.value
+          .map((characteristic) => characteristic.uuid.toString().toLowerCase())
+          .toSet();
+
+  Future<void> _applyConnectionPhase(BleConnectionPhase phase) async {
+    if (phase == BleConnectionPhase.idle) {
+      await _stopListening();
+      geolocationBloc.stopListening();
+      return;
+    }
+
+    if (phase != BleConnectionPhase.connected) {
+      return;
+    }
+
+    if (!geolocationBloc.isListening) {
+      geolocationBloc.startListening().catchError(
+            (error, stackTrace) =>
+                ErrorService.handleError(error, stackTrace),
+          );
+    }
+
+    await _stopListening();
+    await _startListening();
   }
 
   Future<void> _onRecordingStart() async {
-    _clearAllSensorBuffersForNewRecording();
-    
-    if (!kReleaseMode) {
-      final envValue =
-          dotenv.get('ENABLE_SENSOR_CSV_LOGGING', fallback: 'false');
-      final enableLogging = envValue.toLowerCase() == 'true';
-      if (enableLogging) {
-        final csvLogger = SensorCsvLoggerService();
-        csvLogger.startLogging(_sensors);
-      }
+    for (final sensor in _sensors) {
+      sensor.clearBuffersForNewRecording();
     }
-    
+
+    if (_isCsvLoggingEnabled) {
+      SensorCsvLoggerService().startLogging(_sensors);
+    }
+
     final directUploadService = recordingBloc.directUploadService;
     if (directUploadService != null) {
-
       for (final sensor in _sensors) {
         sensor.setDirectUploadService(directUploadService);
       }
-
       directUploadService.enable();
-    }
-    
-    if (!geolocationBloc.isListening) {
-      await geolocationBloc.startListening();
     }
 
     await geolocationBloc.getCurrentLocationAndEmit();
   }
 
   Future<void> _onRecordingStop() async {
-    // Stop CSV logging (only in debug mode if enabled in .env)
-    if (!kReleaseMode) {
-      final enableLogging = dotenv
-              .get('ENABLE_SENSOR_CSV_LOGGING', fallback: 'false')
-              .toLowerCase() ==
-          'true';
-      if (enableLogging) {
-        final csvLogger = SensorCsvLoggerService();
-        await csvLogger.stopLogging();
-      }
+    if (_isCsvLoggingEnabled) {
+      await SensorCsvLoggerService().stopLogging();
     }
-    
+
     final directUploadService = recordingBloc.directUploadService;
     if (directUploadService != null) {
       await directUploadService.uploadRemainingBufferedData();
       directUploadService.disable();
     }
+
+    await geolocationBloc.emitFinalGeolocation();
   }
 
-  bool _listEqualsUnordered(List<String> a, List<String> b) {
-    final aSorted = List<String>.from(a)..sort();
-    final bSorted = List<String>.from(b)..sort();
-    return aSorted.length == bSorted.length &&
-        aSorted.every((element) => bSorted.contains(element));
-  }
-
-  void _initializeSensors() {
-    final isarService = geolocationBloc.isarService;
-
-    _sensors.add(TemperatureSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(
-        HumiditySensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(
-        DistanceSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(
-        DistanceRightSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(SurfaceClassificationSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(AccelerationSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(OvertakingPredictionSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(SurfaceAnomalySensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors.add(
-        FinedustSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
-    _sensors
-        .add(GPSSensor(
-        bleBloc, geolocationBloc, recordingBloc, isarService));
+  bool get _isCsvLoggingEnabled {
+    if (kReleaseMode) {
+      return false;
+    }
+    return dotenv
+            .get('ENABLE_SENSOR_CSV_LOGGING', fallback: 'false')
+            .toLowerCase() ==
+        'true';
   }
 
   Future<void> _startListening() async {
     if (_isStartingListening) {
       return;
     }
+
     _isStartingListening = true;
     try {
-      final availableUuids = bleBloc.availableCharacteristics.value
-          .map((c) => c.uuid.toString().toLowerCase())
-          .toSet();
+      final availableUuids = _availableCharacteristicUuids;
 
-      for (var sensor in _sensors) {
+      for (final sensor in _sensors) {
         final uuid = sensor.characteristicUuid.toLowerCase();
         if (!availableUuids.contains(uuid) ||
             !bleBloc.hasCharacteristicStream(uuid)) {
@@ -196,65 +165,40 @@ class SensorBloc with ChangeNotifier {
   }
 
   Future<void> _stopListening() async {
-    for (var sensor in _sensors) {
+    for (final sensor in _sensors) {
       await sensor.stopListening();
-    }
-  }
-
-  Future<void> _restartAllSensors() async {
-    await _stopListening();
-    await _startListening();
-  }
-
-  Future<void> _flushAllSensorBuffers() async {
-    await geolocationBloc.emitFinalGeolocation();
-  }
-
-
-  void _clearAllSensorBuffersForNewRecording() {
-    for (var sensor in _sensors) {
-      sensor.clearBuffersForNewRecording();
     }
   }
 
   List<Sensor> get sensors => _sensors;
 
   List<Widget> getSensorWidgets() {
-    final availableUuids = bleBloc.availableCharacteristics.value
-        .map((e) => e.uuid.toString())
-        .toSet();
+    final availableUuids = _availableCharacteristicUuids;
 
     final availableSensors = _sensors.where((sensor) {
       if (FeatureFlags.hideSurfaceAnomalySensor &&
           sensor.title == 'surface_anomaly') {
         return false;
       }
-      return availableUuids.contains(sensor.characteristicUuid);
+      return availableUuids.contains(sensor.characteristicUuid.toLowerCase());
     }).toList();
 
     availableSensors.sort((a, b) => a.uiPriority.compareTo(b.uiPriority));
     return availableSensors
-        .map<Widget>((sensor) => sensor.buildWidget())
+        .map((sensor) => sensor.buildWidget())
         .toList();
   }
 
-  @override
   void dispose() {
-    bleBloc.selectedDeviceNotifier.removeListener(_selectedDeviceListener);
-    bleBloc.availableCharacteristics.removeListener(_characteristicsListener);
-    bleBloc.characteristicStreamsVersion
-        .removeListener(_characteristicStreamsVersionListener);
-    recordingBloc.isRecordingNotifier.removeListener(_recordingListener);
-    
-    _stopListening().catchError((e, stackTrace) {
-      debugPrint('Error during sensor cleanup: $e');
+    bleBloc.connectionPhaseNotifier.removeListener(_connectionPhaseListener);
+
+    _stopListening().catchError((error, stackTrace) {
+      debugPrint('Error during sensor cleanup: $error');
       debugPrintStack(stackTrace: stackTrace);
     });
-    
+
     for (final sensor in _sensors) {
       sensor.dispose();
     }
-    
-    super.dispose();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,8 +80,7 @@ class _SenseBoxBikeAppState extends State<SenseBoxBikeApp> {
         _openSenseMapBloc!, _settingsBloc!);
     _geolocationBloc =
         GeolocationBloc(_isarService!, _recordingBloc!, _settingsBloc!);
-    _sensorBloc = SensorBloc(
-        _bleBloc!, _geolocationBloc!, _recordingBloc!, _settingsBloc!);
+    _sensorBloc = SensorBloc(_bleBloc!, _geolocationBloc!, _recordingBloc!);
     _mapboxDrawController = MapboxDrawController();
 
     // Preload box configurations and campaigns
@@ -191,10 +190,10 @@ class _SenseBoxBikeAppState extends State<SenseBoxBikeApp> {
       providers: [
         ChangeNotifierProvider.value(value: _settingsBloc!),
         ChangeNotifierProvider.value(value: _trackBloc!),
-        ChangeNotifierProvider.value(value: _recordingBloc!),
+        Provider<RecordingBloc>.value(value: _recordingBloc!),
         Provider<BleBloc>.value(value: _bleBloc!),
-        ChangeNotifierProvider.value(value: _geolocationBloc!),
-        ChangeNotifierProvider.value(value: _sensorBloc!),
+        Provider<GeolocationBloc>.value(value: _geolocationBloc!),
+        Provider<SensorBloc>.value(value: _sensorBloc!),
         ChangeNotifierProvider.value(value: _openSenseMapBloc!),
         ChangeNotifierProvider.value(value: _configurationBloc!),
         ChangeNotifierProvider.value(value: _mapboxDrawController!),

--- a/lib/ui/screens/home_screen.dart
+++ b/lib/ui/screens/home_screen.dart
@@ -18,19 +18,50 @@ import 'package:sensebox_bike/l10n/app_localizations.dart';
 import 'package:sensebox_bike/ui/widgets/common/info_banner.dart';
 import 'package:sensebox_bike/ui/screens/settings_screen.dart';
 
+import 'package:sensebox_bike/ui/widgets/home/recording_ui.dart';
+
 // HomeScreen now delegates sections to smaller widgets
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   final bool isMapActive;
 
   const HomeScreen({super.key, this.isMapActive = true});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  RecordingBloc? _recordingBloc;
+  bool _recordingUiBound = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_recordingUiBound) {
+      return;
+    }
+
+    _recordingUiBound = true;
+    _recordingBloc = context.read<RecordingBloc>();
+    bindRecordingUiCallbacks(
+      context,
+      context.read<OpenSenseMapBloc>(),
+      _recordingBloc!,
+    );
+  }
+
+  @override
+  void dispose() {
+    _recordingUiBound = false;
+    _recordingBloc?.clearUiCallbacks();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final BleBloc bleBloc = Provider.of<BleBloc>(context);
     final RecordingBloc recordingBloc = context.read<RecordingBloc>();
     final SensorBloc sensorBloc = Provider.of<SensorBloc>(context);
-
-    recordingBloc.setContext(context);
 
     return Scaffold(
       body: Column(
@@ -66,7 +97,7 @@ class HomeScreen extends StatelessWidget {
                       children: [
                         SizedBox(
                           width: double.infinity,
-                          child: GeolocationMapWidget(isActive: isMapActive),
+                          child: GeolocationMapWidget(isActive: widget.isMapActive),
                         ),
                         const Positioned(
                           bottom: 0,

--- a/lib/ui/widgets/home/recording_ui.dart
+++ b/lib/ui/widgets/home/recording_ui.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
+import 'package:sensebox_bike/blocs/recording_bloc.dart';
+import 'package:sensebox_bike/models/sensebox.dart';
+import 'package:sensebox_bike/models/track_data.dart';
+import 'package:sensebox_bike/services/batch_upload_service.dart';
+import 'package:sensebox_bike/services/custom_exceptions.dart';
+import 'package:sensebox_bike/services/error_service.dart';
+import 'package:sensebox_bike/ui/widgets/common/upload_progress_modal.dart';
+import 'package:sensebox_bike/ui/widgets/home/ble_connection_dialogs.dart';
+
+Future<void> showBatchUploadAfterRecording({
+  required BuildContext context,
+  required TrackData track,
+  required SenseBox? senseBox,
+  required BatchUploadService batchUploadService,
+  required OpenSenseMapBloc openSenseMapBloc,
+  required VoidCallback onFinished,
+}) async {
+  if (!context.mounted) {
+    batchUploadService.dispose();
+    onFinished();
+    return;
+  }
+
+  final canUpload =
+      senseBox != null && openSenseMapBloc.hasAuthAndSelectedSenseBox;
+
+  try {
+    await track.geolocations.load();
+    if (!context.mounted) {
+      batchUploadService.dispose();
+      onFinished();
+      return;
+    }
+    if (track.geolocations.isEmpty) {
+      throw TrackHasNoGeolocationsException(track.id);
+    }
+
+    UploadProgressOverlay.show(
+      context,
+      batchUploadService: batchUploadService,
+      canUpload: canUpload,
+      isAuthenticated: openSenseMapBloc.isAuthenticated,
+      hasSelectedBox: openSenseMapBloc.selectedSenseBox != null,
+      onUploadComplete: () {
+        batchUploadService.dispose();
+        onFinished();
+        debugPrint('[RecordingUi] Batch upload completed successfully');
+      },
+      onUploadFailed: () {
+        batchUploadService.dispose();
+        onFinished();
+        debugPrint('[RecordingUi] Batch upload failed permanently');
+      },
+      onStartUpload: () {
+        if (canUpload) {
+          unawaited(_uploadTrack(track, senseBox!, batchUploadService));
+        }
+      },
+    );
+  } catch (e, stack) {
+    debugPrint('[RecordingUi] Error showing upload modal: $e');
+    ErrorService.handleError(e, stack);
+    UploadProgressOverlay.hide();
+    batchUploadService.dispose();
+    onFinished();
+  }
+}
+
+Future<void> _uploadTrack(
+  TrackData track,
+  SenseBox senseBox,
+  BatchUploadService batchUploadService,
+) async {
+  try {
+    await batchUploadService.uploadTrack(track, senseBox);
+  } catch (e, stack) {
+    ErrorService.handleError(
+      'Batch upload failed after recording stop: $e',
+      stack,
+      sendToSentry: true,
+    );
+  }
+}
+
+void bindRecordingUiCallbacks(
+  BuildContext context,
+  OpenSenseMapBloc openSenseMapBloc,
+  RecordingBloc recordingBloc,
+) {
+  recordingBloc.setUiCallbacks(
+    onRecordingStoppedDueToBle: () =>
+        showRecordingStoppedDueToBleDialog(context),
+    onBatchUploadPrompt: ({
+      required TrackData track,
+      required SenseBox? senseBox,
+      required BatchUploadService batchUploadService,
+      required VoidCallback onFinished,
+    }) =>
+        showBatchUploadAfterRecording(
+          context: context,
+          track: track,
+          senseBox: senseBox,
+          batchUploadService: batchUploadService,
+          openSenseMapBloc: openSenseMapBloc,
+          onFinished: onFinished,
+        ),
+  );
+}

--- a/test/blocs/recording_bloc_test.dart
+++ b/test/blocs/recording_bloc_test.dart
@@ -1,21 +1,28 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart' as geo;
 import 'package:mocktail/mocktail.dart';
 import 'package:sensebox_bike/blocs/recording_bloc.dart';
-import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
-import 'package:sensebox_bike/blocs/settings_bloc.dart';
-import 'package:sensebox_bike/blocs/track_bloc.dart';
-import 'package:sensebox_bike/services/isar_service.dart';
+import 'package:sensebox_bike/models/ble_connection_phase.dart';
+import 'package:sensebox_bike/models/track_data.dart';
+import 'package:sensebox_bike/services/batch_upload_service.dart';
+import 'package:sensebox_bike/services/opensensemap_service.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import '../mocks.dart';
+import '../test_helpers.dart';
 
 class MockGeolocator extends Mock
     with MockPlatformInterfaceMixin
     implements geo.GeolocatorPlatform {}
 
+class MockOpenSenseMapService extends Mock implements OpenSenseMapService {}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    initializeTestDependencies();
+  });
   
   late MockGeolocator mockGeolocator;
   late MockIsarService mockIsarService;
@@ -172,6 +179,96 @@ void main() {
 
       // Assert
       expect(recordingBloc.isRecording, isFalse);
+    });
+  });
+
+  group('RecordingBloc UI callbacks', () {
+    test('invokes onRecordingStoppedDueToBle when stopping due to disconnect',
+        () async {
+      var called = false;
+      recordingBloc.setUiCallbacks(
+        onRecordingStoppedDueToBle: () async {
+          called = true;
+        },
+      );
+      recordingBloc.isRecordingNotifier.value = true;
+
+      await recordingBloc.stopRecording(dueToBleDisconnect: true);
+
+      expect(called, isTrue);
+      expect(recordingBloc.isRecording, isFalse);
+    });
+
+    test('clearUiCallbacks prevents onRecordingStoppedDueToBle', () async {
+      var called = false;
+      recordingBloc.setUiCallbacks(
+        onRecordingStoppedDueToBle: () async {
+          called = true;
+        },
+      );
+      recordingBloc.clearUiCallbacks();
+      recordingBloc.isRecordingNotifier.value = true;
+
+      await recordingBloc.stopRecording(dueToBleDisconnect: true);
+
+      expect(called, isFalse);
+    });
+
+    test('ble connection error stops recording and invokes disconnect callback',
+        () async {
+      var called = false;
+      recordingBloc.setUiCallbacks(
+        onRecordingStoppedDueToBle: () async {
+          called = true;
+        },
+      );
+      recordingBloc.isRecordingNotifier.value = true;
+
+      mockBleBloc.connectionErrorNotifier.value = true;
+
+      expect(recordingBloc.isRecording, isFalse);
+      expect(called, isTrue);
+    });
+
+    test('invokes onBatchUploadPrompt after batch-mode recording stops',
+        () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final mockOpenSenseMapService = MockOpenSenseMapService();
+      when(() => mockOpenSenseMapBloc.openSenseMapService)
+          .thenReturn(mockOpenSenseMapService);
+      when(() => mockGeolocator.isLocationServiceEnabled())
+          .thenAnswer((_) async => true);
+      when(() => mockGeolocator.checkPermission())
+          .thenAnswer((_) async => geo.LocationPermission.whileInUse);
+      when(() => mockBleBloc.isReadyForRecording).thenReturn(true);
+      when(() => mockTrackBloc.startNewTrack(
+            isDirectUpload: any(named: 'isDirectUpload'),
+          )).thenAnswer((_) async => 1);
+      final track = TrackData()..id = 1;
+      when(() => mockTrackBloc.currentTrack).thenReturn(track);
+
+      var promptCalled = false;
+      recordingBloc.setUiCallbacks(
+        onBatchUploadPrompt: ({
+          required track,
+          required senseBox,
+          required batchUploadService,
+          required onFinished,
+        }) async {
+          promptCalled = true;
+          batchUploadService.dispose();
+          onFinished();
+        },
+      );
+
+      await recordingBloc.startRecording();
+      expect(recordingBloc.isRecording, isTrue);
+
+      await recordingBloc.stopRecording();
+
+      expect(promptCalled, isTrue);
     });
   });
 }

--- a/test/blocs/sensor_bloc_test.dart
+++ b/test/blocs/sensor_bloc_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sensebox_bike/blocs/sensor_bloc.dart';
+import '../mocks.dart';
+
+void _mockMapboxAccessTokenChannel() {
+  const codec = StandardMessageCodec();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler(
+    'dev.flutter.pigeon.mapbox_maps_flutter._MapboxOptions.setAccessToken',
+    (ByteData? message) async =>
+        codec.encodeMessage(<Object?>[]),
+  );
+}
+
+void main() {
+  late MockBleBloc mockBleBloc;
+  late MockGeolocationBloc mockGeolocationBloc;
+  late MockRecordingBloc mockRecordingBloc;
+  late MockIsarService mockIsarService;
+  Future<void> Function()? onRecordingStart;
+
+  setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    _mockMapboxAccessTokenChannel();
+    dotenv.testLoad(
+      fileInput: 'MAPBOX_ACCESS_TOKEN=test\nENABLE_SENSOR_CSV_LOGGING=false\n',
+    );
+  });
+
+  test('onRecordingStart emits current location without starting geo listener',
+      () async {
+    mockBleBloc = MockBleBloc();
+    mockGeolocationBloc = MockGeolocationBloc();
+    mockRecordingBloc = MockRecordingBloc();
+    mockIsarService = MockIsarService();
+
+    when(() => mockGeolocationBloc.isarService).thenReturn(mockIsarService);
+    when(() => mockGeolocationBloc.startListening()).thenAnswer((_) async {});
+    when(() => mockGeolocationBloc.getCurrentLocationAndEmit())
+        .thenAnswer((_) async {});
+    when(() => mockRecordingBloc.directUploadService).thenReturn(null);
+    when(
+      () => mockRecordingBloc.setRecordingCallbacks(
+        onRecordingStart: any(named: 'onRecordingStart'),
+        onRecordingStop: any(named: 'onRecordingStop'),
+      ),
+    ).thenAnswer((invocation) {
+      onRecordingStart = invocation.namedArguments[#onRecordingStart]
+          as Future<void> Function()?;
+    });
+
+    final sensorBloc = SensorBloc(
+      mockBleBloc,
+      mockGeolocationBloc,
+      mockRecordingBloc,
+    );
+    await Future<void>.delayed(Duration.zero);
+    addTearDown(() {
+      mockBleBloc.dispose();
+      sensorBloc.dispose();
+    });
+
+    expect(onRecordingStart, isNotNull);
+
+    await onRecordingStart!();
+
+    verifyNever(() => mockGeolocationBloc.startListening());
+    verify(() => mockGeolocationBloc.getCurrentLocationAndEmit()).called(1);
+  });
+}

--- a/test/localization/tracks_screen_test.dart
+++ b/test/localization/tracks_screen_test.dart
@@ -67,7 +67,7 @@ void main() {
             ChangeNotifierProvider<TrackBloc>.value(
               value: mockTrackBloc,
             ),
-            ChangeNotifierProvider<RecordingBloc>.value(
+            Provider<RecordingBloc>.value(
               value: mockRecordingBloc,
             ),
             ChangeNotifierProvider<OpenSenseMapBloc>.value(

--- a/test/ui/widgets/opensensemap/create_bike_box_dialog_test.dart
+++ b/test/ui/widgets/opensensemap/create_bike_box_dialog_test.dart
@@ -102,7 +102,7 @@ void main() {
             providers: [
               ChangeNotifierProvider<OpenSenseMapBloc>.value(
                   value: mockOpenSenseMapBloc),
-              ChangeNotifierProvider<GeolocationBloc>.value(
+              Provider<GeolocationBloc>.value(
                   value: mockGeolocationBloc),
                 ChangeNotifierProvider<ConfigurationBloc>.value(
                   value: mockConfigurationBloc),
@@ -352,7 +352,7 @@ void main() {
             providers: [
               ChangeNotifierProvider<OpenSenseMapBloc>.value(
                   value: mockOpenSenseMapBloc),
-              ChangeNotifierProvider<GeolocationBloc>.value(
+              Provider<GeolocationBloc>.value(
                   value: mockGeolocationBloc),
                 ChangeNotifierProvider<ConfigurationBloc>.value(
                   value: mockConfigurationBloc),


### PR DESCRIPTION
## Summary
- RecordingBloc UI callbacks replace BuildContext usage
- Upload modal logic moved to `recording_ui.dart`
- SensorBloc geolocation dedupe on recording start
- `_recordingUiBound` guard prevents duplicate callback binding
Depends on: BLE refactor PR
## Test plan
- [ ] Start/stop recording
- [ ] Recording stops on BLE disconnect with dialog
- [ ] Batch upload prompt after batch-mode recording
