### PR TITLE
fix: add support for the new box configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ Closes #
 [ ] I have performed a self-review of my code
 [ ] I have added or updated tests
 [ ] I have added or updated relevant documentation
+[ ] I checked whether this change could break the app for people who already have it installed (for example remote config, file formats, or required updates)
 
 ### Additional Information
 

--- a/data/box_configurations_v2.json
+++ b/data/box_configurations_v2.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "lauds_26",
+    "displayName": "LAUDS 26",
+    "defaultGrouptag": "lauds_26",
+    "sensors": [
+      { "key": "distance", "title": "Distance Left" },
+      { "key": "distance_right" },
+      { "key": "overtaking" },
+      { "key": "finedust", "attribute": "pm1" },
+      { "key": "finedust", "attribute": "pm2.5" },
+      { "key": "finedust", "attribute": "pm4" },
+      { "key": "finedust", "attribute": "pm10" },
+      { "key": "surface_classification", "attribute": "asphalt" },
+      { "key": "surface_classification", "attribute": "sett" },
+      { "key": "surface_classification", "attribute": "compacted" },
+      { "key": "surface_classification", "attribute": "paving" },
+      { "key": "surface_classification", "attribute": "standing" },
+      { "key": "surface_anomaly" },
+      { "key": "gps", "attribute": "speed" }
+    ]
+  },
+  {
+    "id": "atrai",
+    "displayName": "2025",
+    "defaultGrouptag": "atrai",
+    "sensors": [
+      { "key": "distance", "title": "Overtaking Distance" },
+      { "key": "overtaking" },
+      { "key": "temperature" },
+      { "key": "humidity" },
+      { "key": "finedust", "attribute": "pm1" },
+      { "key": "finedust", "attribute": "pm2.5" },
+      { "key": "finedust", "attribute": "pm4" },
+      { "key": "finedust", "attribute": "pm10" },
+      { "key": "surface_classification", "attribute": "asphalt" },
+      { "key": "surface_classification", "attribute": "sett" },
+      { "key": "surface_classification", "attribute": "compacted" },
+      { "key": "surface_classification", "attribute": "paving" },
+      { "key": "surface_classification", "attribute": "standing" },
+      { "key": "surface_anomaly" },
+      { "key": "gps", "attribute": "speed" }
+    ]
+  },
+  {
+    "id": "classic",
+    "displayName": "2022",
+    "defaultGrouptag": "classic",
+    "sensors": [
+      { "key": "distance", "title": "Overtaking Distance" },
+      { "key": "temperature" },
+      { "key": "humidity" },
+      { "key": "finedust", "attribute": "pm1" },
+      { "key": "finedust", "attribute": "pm2.5" },
+      { "key": "finedust", "attribute": "pm4" },
+      { "key": "finedust", "attribute": "pm10" },
+      { "key": "acceleration", "attribute": "x" },
+      { "key": "acceleration", "attribute": "y" },
+      { "key": "acceleration", "attribute": "z" },
+      { "key": "gps", "attribute": "speed" }
+    ]
+  }
+]

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -30,11 +30,13 @@ const githubDataBaseUrl =
 
 const apiUrlsPath = '/api_urls.json';
 const campaignsPath = '/locations.json';
-const boxConfigurationsPath = '/box_configurations.json';
+// Legacy inline format kept at /box_configurations.json for older app releases.
+// Current builds use the catalog-keyed v2 file.
+const boxConfigurationsPath = '/box_configurations_v2.json';
 const sensorsPath = '/sensors.json';
 
 const sensorsAssetPath = 'data/sensors.json';
-const boxConfigurationsAssetPath = 'data/box_configurations.json';
+const boxConfigurationsAssetPath = 'data/box_configurations_v2.json';
 
 const apiUrlsUrl = '$githubDataBaseUrl$apiUrlsPath';
 const campaignsUrl = '$githubDataBaseUrl$campaignsPath';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -103,6 +103,8 @@ flutter:
     - assets/images/sensebox_bike_logo.svg
     - assets/images/sensebox_bike_classic.webp
     - assets/images/sensebox_bike_atrai.webp
+    - data/sensors.json
+    - data/box_configurations_v2.json
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/test/blocs/configuration_bloc_test.dart
+++ b/test/blocs/configuration_bloc_test.dart
@@ -5,45 +5,91 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sensebox_bike/blocs/configuration_bloc.dart';
-import 'package:sensebox_bike/services/remote_data_service.dart';
 import 'package:sensebox_bike/constants.dart';
+import 'package:sensebox_bike/services/remote_data_service.dart';
+
+import '../helpers/box_configurations_test_support.dart';
 import '../sensor_catalog_test_data.dart';
 
 class MockRemoteDataService extends Mock implements RemoteDataService {}
 
 Future<dynamic> _loadTestBundledJson(String assetPath) async {
-  final file = File(assetPath);
-  return json.decode(await file.readAsString());
+  return json.decode(await File(assetPath).readAsString());
 }
+
+final _classicBoxConfig = {
+  'id': 'classic',
+  'displayName': '2022',
+  'defaultGrouptag': 'classic',
+  'sensors': [
+    {'key': 'temperature'},
+    {'key': 'humidity'},
+  ],
+};
+
+final _remoteBoxConfigs = [
+  {
+    'id': 'classic',
+    'displayName': '2022',
+    'defaultGrouptag': 'classic',
+    'sensors': [
+      {'key': 'temperature'},
+    ],
+  },
+  {
+    'id': 'atrai',
+    'displayName': '2025',
+    'defaultGrouptag': 'atrai',
+    'sensors': <Map<String, dynamic>>[],
+  },
+];
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ConfigurationBloc', () {
-    late MockRemoteDataService mockRemoteDataService;
+    late MockRemoteDataService remote;
     late ConfigurationBloc bloc;
 
-    final mockBoxConfigurations = [
-      {
-        'id': 'classic',
-        'displayName': '2022',
-        'defaultGrouptag': 'classic',
-        'sensors': [
-          {'key': 'temperature'},
-          {'key': 'humidity'},
-        ],
-      },
-    ];
+    void stubSensors([Object? response]) {
+      if (response is Exception) {
+        when(() => remote.fetchJson(sensorsUrl)).thenThrow(response);
+      } else {
+        when(() => remote.fetchJson(sensorsUrl)).thenAnswer(
+          (_) async => response ?? mockSensorCatalogJson,
+        );
+      }
+    }
+
+    void stubBoxConfigs(Object response) {
+      if (response is Exception) {
+        when(() => remote.fetchJson(boxConfigurationsUrl)).thenThrow(response);
+      } else {
+        when(() => remote.fetchJson(boxConfigurationsUrl))
+            .thenAnswer((_) async => response);
+      }
+    }
+
+    void expectBundledProfilesLoaded({String? laudsFirstTitle}) {
+      expect(bloc.boxConfigurations, isNotNull);
+      expect(bloc.boxConfigurationsError, isNull);
+      expectHasBoxProfileIds(bloc.boxConfigurations!);
+      if (laudsFirstTitle != null) {
+        expect(
+          requireProfile(bloc.boxConfigurations!, 'lauds_26').sensors.first.title,
+          laudsFirstTitle,
+        );
+      }
+    }
 
     setUp(() {
-      mockRemoteDataService = MockRemoteDataService();
+      remote = MockRemoteDataService();
       bloc = ConfigurationBloc(
-        remoteDataService: mockRemoteDataService,
+        remoteDataService: remote,
         loadBundledJson: _loadTestBundledJson,
       );
-      reset(mockRemoteDataService);
-      when(() => mockRemoteDataService.fetchJson(sensorsUrl))
-          .thenAnswer((_) async => mockSensorCatalogJson);
+      reset(remote);
+      stubSensors();
     });
 
     tearDown(clearMockSensorCatalog);
@@ -58,49 +104,36 @@ void main() {
       expect(bloc.campaignsError, isNull);
     });
 
+    test('points remote and asset paths at catalog-keyed v2 configs', () {
+      expect(boxConfigurationsPath, '/box_configurations_v2.json');
+      expect(boxConfigurationsAssetPath, v2BoxConfigurationsPath);
+      expect(boxConfigurationsUrl, endsWith('/box_configurations_v2.json'));
+    });
+
     group('loadSensorCatalog()', () {
       test('loads and parses sensor catalog successfully', () async {
         await bloc.loadSensorCatalog();
 
         expect(bloc.sensorCatalog, isNotNull);
-        expect(bloc.sensorCatalog!.length, 3);
+        expect(bloc.sensorCatalog!.length, mockSensorCatalogJson.length);
         expect(bloc.isLoadingSensorCatalog, false);
         expect(bloc.sensorCatalogError, isNull);
-        verify(() => mockRemoteDataService.fetchJson(sensorsUrl)).called(1);
+        verify(() => remote.fetchJson(sensorsUrl)).called(1);
       });
     });
 
     group('loadBoxConfigurations()', () {
-      final boxConfigs = [
-        {
-          'id': 'classic',
-          'displayName': '2022',
-          'defaultGrouptag': 'classic',
-          'sensors': [
-            {'key': 'temperature'},
-          ],
-        },
-        {
-          'id': 'atrai',
-          'displayName': '2025',
-          'defaultGrouptag': 'atrai',
-          'sensors': [],
-        },
-      ];
-
       test('loads and parses box configurations successfully', () async {
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenAnswer((_) async => boxConfigs);
+        stubBoxConfigs(_remoteBoxConfigs);
 
         await bloc.loadBoxConfigurations();
 
         expect(bloc.boxConfigurations, isNotNull);
         expect(bloc.boxConfigurations!.length, 3);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'classic'),
-            true);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'atrai'),
-            true);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'all'), true);
+        expect(
+          bloc.boxConfigurations!.map((c) => c.id),
+          containsAll(['classic', 'atrai', 'all']),
+        );
         expect(
           bloc.boxConfigurations!.last.sensors.length,
           bloc.sensorCatalog!.length,
@@ -108,44 +141,34 @@ void main() {
         expect(bloc.boxConfigurations!.first.sensors.first.title, 'Temperature');
         expect(bloc.isLoadingBoxConfigurations, false);
         expect(bloc.boxConfigurationsError, isNull);
-        verify(() => mockRemoteDataService.fetchJson(sensorsUrl)).called(1);
-        verify(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .called(1);
+        verify(() => remote.fetchJson(sensorsUrl)).called(1);
+        verify(() => remote.fetchJson(boxConfigurationsUrl)).called(1);
       });
 
       test('sets loading state during load', () async {
         await bloc.loadSensorCatalog();
 
         final completer = Completer<List<dynamic>>();
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
+        when(() => remote.fetchJson(boxConfigurationsUrl))
             .thenAnswer((_) => completer.future);
 
         final loadFuture = bloc.loadBoxConfigurations();
         expect(bloc.isLoadingBoxConfigurations, true);
 
-        completer.complete(boxConfigs);
+        completer.complete(_remoteBoxConfigs);
         await loadFuture;
 
         expect(bloc.isLoadingBoxConfigurations, false);
       });
 
-      test('falls back to bundled box configurations when remote fails', () async {
-        when(() => mockRemoteDataService.fetchJson(sensorsUrl))
-            .thenThrow(Exception('Network error'));
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenThrow(Exception('Network error'));
+      test('falls back to bundled box configurations when remote fails',
+          () async {
+        stubSensors(Exception('Network error'));
+        stubBoxConfigs(Exception('Network error'));
 
         await bloc.loadBoxConfigurations();
 
-        expect(bloc.boxConfigurations, isNotNull);
-        expect(bloc.boxConfigurationsError, isNull);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'lauds_26'),
-            true);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'atrai'),
-            true);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'classic'),
-            true);
-        expect(bloc.boxConfigurations!.any((config) => config.id == 'all'), true);
+        expectBundledProfilesLoaded();
         expect(
           bloc.boxConfigurations!.last.sensors.length,
           bloc.sensorCatalog!.length,
@@ -154,22 +177,32 @@ void main() {
       });
 
       test('falls back to bundled data when remote format is invalid', () async {
-        when(() => mockRemoteDataService.fetchJson(sensorsUrl))
-            .thenAnswer((_) async => {'invalid': 'format'});
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenAnswer((_) async => {'invalid': 'format'});
+        stubSensors({'invalid': 'format'});
+        stubBoxConfigs({'invalid': 'format'});
 
         await bloc.loadBoxConfigurations();
 
-        expect(bloc.boxConfigurations, isNotNull);
-        expect(bloc.boxConfigurationsError, isNull);
+        expectBundledProfilesLoaded();
         expect(bloc.boxConfigurations!.length, 4);
         expect(bloc.isLoadingBoxConfigurations, false);
       });
 
+      test('falls back to bundled v2 when remote returns legacy inline format',
+          () async {
+        final legacyConfigs =
+            loadJsonListFromFile(legacyBoxConfigurationsPath);
+
+        // Force full bundled sensors.json so v2 catalog refs can resolve.
+        stubSensors(Exception('Network error'));
+        stubBoxConfigs(legacyConfigs);
+
+        await bloc.loadBoxConfigurations();
+
+        expectBundledProfilesLoaded(laudsFirstTitle: 'Distance Left');
+      });
+
       test('reloads when allowReload is true', () async {
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenAnswer((_) async => boxConfigs);
+        stubBoxConfigs(_remoteBoxConfigs);
 
         await bloc.loadBoxConfigurations();
         final firstLoadId = bloc.boxConfigurations?.first.id;
@@ -178,22 +211,19 @@ void main() {
         final secondLoadId = bloc.boxConfigurations?.first.id;
 
         expect(firstLoadId, isNotNull);
-        expect(secondLoadId, equals(firstLoadId));
-        verify(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .called(2);
+        expect(secondLoadId, firstLoadId);
+        verify(() => remote.fetchJson(boxConfigurationsUrl)).called(2);
       });
     });
 
     group('loadAll()', () {
-      final mockCampaigns = [
-        {'label': 'Wiesbaden', 'value': 'wiesbaden'},
-      ];
-
       test('loads catalog, box configurations, and campaigns', () async {
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenAnswer((_) async => mockBoxConfigurations);
-        when(() => mockRemoteDataService.fetchJson(campaignsUrl))
-            .thenAnswer((_) async => mockCampaigns);
+        stubBoxConfigs([_classicBoxConfig]);
+        when(() => remote.fetchJson(campaignsUrl)).thenAnswer(
+          (_) async => [
+            {'label': 'Wiesbaden', 'value': 'wiesbaden'},
+          ],
+        );
 
         await bloc.loadAll();
 
@@ -213,15 +243,17 @@ void main() {
     });
 
     group('getBoxConfigurationById()', () {
+      Future<void> loadClassicConfig() async {
+        stubBoxConfigs([_classicBoxConfig]);
+        await bloc.loadBoxConfigurations();
+      }
+
       test('returns null when configurations not loaded', () {
         expect(bloc.getBoxConfigurationById('classic'), isNull);
       });
 
       test('returns configuration when found', () async {
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenAnswer((_) async => mockBoxConfigurations);
-
-        await bloc.loadBoxConfigurations();
+        await loadClassicConfig();
 
         final config = bloc.getBoxConfigurationById('classic');
         expect(config, isNotNull);
@@ -230,10 +262,7 @@ void main() {
       });
 
       test('returns null when configuration not found', () async {
-        when(() => mockRemoteDataService.fetchJson(boxConfigurationsUrl))
-            .thenAnswer((_) async => mockBoxConfigurations);
-
-        await bloc.loadBoxConfigurations();
+        await loadClassicConfig();
 
         expect(bloc.getBoxConfigurationById('unknown_nonexistent_id'), isNull);
       });

--- a/test/data/box_configurations_compat_test.dart
+++ b/test/data/box_configurations_compat_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sensebox_bike/models/box_configuration.dart';
+
+import '../helpers/box_configurations_test_support.dart';
+import '../sensor_catalog_test_data.dart';
+
+/// Dual-file contract for box configs:
+/// - [legacyBoxConfigurationsPath] keeps the inline shape for older installs
+/// - [v2BoxConfigurationsPath] is the catalog-keyed shape for the current parser
+///
+/// Manual smoke after merge to main (not automated here):
+/// - Older / store APK: remote `.../data/box_configurations.json` → models load
+/// - This branch build: remote or bundled `box_configurations_v2.json` → models load
+/// - New build offline: bundled v2 asset fallback → same models
+void main() {
+  group('box configuration dual-file contract', () {
+    test('legacy file keeps inline shape for older app installs', () {
+      final ids = <String>{};
+
+      for (final item in loadJsonListFromFile(legacyBoxConfigurationsPath)) {
+        final config = asJsonObject(item, legacyBoxConfigurationsPath);
+        expectBoxConfigHeader(config, legacyBoxConfigurationsPath);
+        ids.add(config['id'] as String);
+
+        final sensors = config['sensors'] as List<dynamic>;
+        for (var i = 0; i < sensors.length; i++) {
+          final context = '${config['id']}[$i]';
+          final sensor = asJsonObject(sensors[i], context);
+
+          for (final field in legacyInlineSensorFields) {
+            expectNonEmptyString(
+              sensor[field],
+              reason: '$context missing inline "$field"',
+            );
+          }
+          expect(
+            sensor.containsKey('key'),
+            isFalse,
+            reason: '$context must not use catalog "key"',
+          );
+        }
+      }
+
+      expectContainsModelIds(ids);
+    });
+
+    test('v2 file uses catalog-keyed shape for current app', () {
+      final ids = <String>{};
+
+      for (final item in loadJsonListFromFile(v2BoxConfigurationsPath)) {
+        final config = asJsonObject(item, v2BoxConfigurationsPath);
+        expectBoxConfigHeader(config, v2BoxConfigurationsPath);
+        ids.add(config['id'] as String);
+
+        final sensors = config['sensors'] as List<dynamic>;
+        for (var i = 0; i < sensors.length; i++) {
+          final context = '${config['id']}[$i]';
+          final sensor = asJsonObject(sensors[i], context);
+
+          expectNonEmptyString(
+            sensor['key'],
+            reason: '$context missing catalog "key"',
+          );
+          for (final field in sensor.keys) {
+            expect(
+              catalogRefSensorFields.contains(field),
+              isTrue,
+              reason: '$context unexpected field "$field"',
+            );
+          }
+        }
+      }
+
+      expectContainsModelIds(ids);
+    });
+  });
+
+  group('current app parser vs dual files', () {
+    setUp(setupSensorCatalogFromRepo);
+    tearDown(clearMockSensorCatalog);
+
+    test('parses every v2 box configuration with real sensors.json', () {
+      final parsed = <String, BoxConfiguration>{};
+      for (final item in loadJsonListFromFile(v2BoxConfigurationsPath)) {
+        final config = BoxConfiguration.fromJson(
+          asJsonObject(item, v2BoxConfigurationsPath),
+        );
+        parsed[config.id] = config;
+      }
+
+      expectContainsModelIds(parsed.keys);
+
+      final lauds = requireProfile(parsed.values, 'lauds_26');
+      expect(lauds.sensors.first.title, 'Distance Left');
+      expect(lauds.sensors.first.key, 'distance');
+
+      final atrai = requireProfile(parsed.values, 'atrai');
+      expect(atrai.sensors.first.title, 'Overtaking Distance');
+      expect(atrai.sensors.first.key, 'distance');
+
+      final classic = requireProfile(parsed.values, 'classic');
+      expect(classic.sensors.any((s) => s.key == 'temperature'), isTrue);
+    });
+
+    test('rejects legacy inline box configurations', () {
+      final first = asJsonObject(
+        loadJsonListFromFile(legacyBoxConfigurationsPath).first,
+        legacyBoxConfigurationsPath,
+      );
+
+      expect(
+        () => BoxConfiguration.fromJson(first),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('missing required field "key"'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/helpers/box_configurations_test_support.dart
+++ b/test/helpers/box_configurations_test_support.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sensebox_bike/models/box_configuration.dart';
+
+/// Legacy inline format kept for older app installs.
+const legacyBoxConfigurationsPath = 'data/box_configurations.json';
+
+/// Catalog-keyed format required by the current app parser.
+const v2BoxConfigurationsPath = 'data/box_configurations_v2.json';
+
+const expectedBoxModelIds = {'atrai', 'lauds_26', 'classic'};
+
+const legacyInlineSensorFields = {
+  'id',
+  'icon',
+  'title',
+  'unit',
+  'sensorType',
+};
+
+const catalogRefSensorFields = {'key', 'attribute', 'title', 'id'};
+
+List<dynamic> loadJsonListFromFile(String path) {
+  final file = File(path);
+  expect(file.existsSync(), isTrue, reason: '$path must exist');
+  final decoded = jsonDecode(file.readAsStringSync());
+  expect(decoded, isA<List>(), reason: '$path must be a JSON list');
+  final list = decoded as List<dynamic>;
+  expect(list, isNotEmpty, reason: '$path must not be empty');
+  return list;
+}
+
+Map<String, dynamic> asJsonObject(dynamic value, String context) {
+  expect(value, isA<Map>(), reason: '$context must be an object');
+  return Map<String, dynamic>.from(value as Map);
+}
+
+void expectNonEmptyString(
+  dynamic value, {
+  required String reason,
+}) {
+  expect(value, isA<String>(), reason: reason);
+  expect((value as String).isNotEmpty, isTrue, reason: reason);
+}
+
+/// Shared top-level fields for both legacy and v2 box config objects.
+void expectBoxConfigHeader(Map<String, dynamic> config, String context) {
+  expectNonEmptyString(config['id'], reason: '$context missing id');
+  expectNonEmptyString(
+    config['displayName'],
+    reason: '$context missing displayName',
+  );
+  expectNonEmptyString(
+    config['defaultGrouptag'],
+    reason: '$context missing defaultGrouptag',
+  );
+  expect(config['sensors'], isA<List>(), reason: '$context missing sensors');
+  expect(
+    (config['sensors'] as List).isNotEmpty,
+    isTrue,
+    reason: '$context needs sensors',
+  );
+}
+
+void expectContainsModelIds(Iterable<String> ids) {
+  expect(ids.toSet(), containsAll(expectedBoxModelIds));
+}
+
+void expectHasBoxProfileIds(
+  Iterable<BoxConfiguration> configs, {
+  bool includeAll = true,
+}) {
+  final ids = configs.map((c) => c.id).toSet();
+  expectContainsModelIds(ids);
+  if (includeAll) {
+    expect(ids, contains('all'));
+  }
+}
+
+BoxConfiguration requireProfile(
+  Iterable<BoxConfiguration> configs,
+  String id,
+) {
+  return configs.firstWhere((c) => c.id == id);
+}


### PR DESCRIPTION
Closes #

Restore box configuration loading for current app builds while keeping the
legacy remote file for people still on older releases.

### Detailed Changes
* Add `data/box_configurations_v2.json` with the catalog-keyed format (`key` / `attribute`) that the current parser expects
* Point remote and bundled asset paths in `lib/constants.dart` to `box_configurations_v2.json`
* Keep `data/box_configurations.json` unchanged (legacy inline format for older apps fetching from `main`)
* Bundle `data/sensors.json` and `data/box_configurations_v2.json` in `pubspec.yaml` for offline fallback
* Add a PR checklist item about checking whether a change could break existing installs

### Testing
* `flutter test test/blocs/configuration_bloc_test.dart`
* Cold start the app, open create/select senseBox, confirm LAUDS 26 / 2025 / 2022 models load
* Confirm older installs still fetch `box_configurations.json` successfully after this is on `main`

### Checklist before requesting a review

[x] I have performed a self-review of my code
[x] I have added or updated tests
[ ] I have added or updated relevant documentation
[x] I checked whether this change could break the app for people who already have it installed (for example remote config, file formats, or required updates)

### Additional Information

Current builds require sensors with a `key` field. Replacing `box_configurations.json` in place would break older releases. Shipping v2 lets both versions keep working.