### PR TITLE
Chore/bump adnroiid api to 36

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           channel: stable
           cache: true
-          flutter-version: "3.44.5"
+          flutter-version: "3.44.7"
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
            channel: stable
            cache: true
            architecture: x64
-           flutter-version: '3.44.5'
+           flutter-version: '3.44.7'
 
       - name: Create .env file
         run: |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -13,7 +13,9 @@ dependencies {
 
 android {
     namespace = "de.reedu.senseboxbike"
-    compileSdk = flutter.compileSdkVersion
+    // Floor at API 36 so Play builds stay compliant even if an older Flutter
+    // SDK still defaults lower; follow Flutter when it goes higher.
+    compileSdk = Math.max(flutter.compileSdkVersion as Integer, 36)
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
@@ -31,8 +33,9 @@ android {
         applicationId = "de.reedu.senseboxbike"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
+        // Do not floor minSdk at 36 — that would require Android 16+ only.
         minSdkVersion flutter.minSdkVersion
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = Math.max(flutter.targetSdkVersion as Integer, 36)
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,18 @@ subprojects {
     project.evaluationDependsOn(":app")
 }
 
+// Kotlin 2.2+ rejects languageVersion < 1.8. Some plugins (e.g. sentry_flutter 8.x)
+// still pin 1.6; raise the floor so the project builds with AGP/Kotlin for API 36.
+// 1.9 is required by plugins that use enum entries (e.g. haptic_feedback).
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            languageVersion = "1.9"
+            apiVersion = "1.9"
+        }
+    }
+}
+
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.9.0' apply false
-    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/lib/ui/widgets/common/api_url_dialog.dart
+++ b/lib/ui/widgets/common/api_url_dialog.dart
@@ -200,7 +200,7 @@ class _ApiUrlDialogState extends State<ApiUrlDialog> {
         mainAxisSize: MainAxisSize.min,
         children: [
           DropdownButtonFormField<String>(
-            value: _dropdownValue,
+            initialValue: _dropdownValue,
             isExpanded: true,
             decoration: InputDecoration(labelText: translations.settingsApiUrl),
             selectedItemBuilder: (context) => [

--- a/lib/ui/widgets/common/dropdown_form_field.dart
+++ b/lib/ui/widgets/common/dropdown_form_field.dart
@@ -14,9 +14,7 @@ class DropdownFormField<T> extends FormField<T> {
   }) : super(
           builder: (FormFieldState<T> state) {
             return DropdownButtonFormField<T>(
-              // ignore: deprecated_member_use
-              // Using 'value' for compatibility with Flutter 3.29.1
-              value: state.value,
+              initialValue: state.value,
               decoration: InputDecoration(
                 labelText: labelText,
                 errorText: state.errorText,


### PR DESCRIPTION
Closes #

Bump the Android / Flutter toolchain so release builds target API 36
(Google Play requirement from August 31, 2026).

### Detailed Changes
* Floor `compileSdk` / `targetSdk` at 36 in `android/app/build.gradle` (follow Flutter if higher)
* Bump AGP to 8.11.1, Gradle to 8.14, Kotlin to 2.2.20
* Raise plugin Kotlin `languageVersion` to 1.9 (needed for Kotlin 2.2 + sentry_flutter 8.x)
* Bump CI Flutter to 3.44.7 so release builds pick up targetSdk 36 defaults
* Replace deprecated `DropdownButtonFormField.value` with `initialValue`

### Testing
* [x] App cold-starts on a physical Android device
* [x] BLE connect + short recording (incl. background) works
* [ ] Optional: release APK / AAB reports `targetSdkVersion='36'`

### Checklist before requesting a review

[x] I have performed a self-review of my code
[ ] I have added or updated tests
[ ] I have added or updated relevant documentation
[x] I checked whether this change could break the app for people who already have it installed (for example remote config, file formats, or required updates)

### Additional Information

Toolchain-only change. No intentional product behavior changes.