### PR TITLE
Cache track aggregates to avoid full GPS history scans

### DIFF
--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -209,8 +209,8 @@ class RecordingBloc with ChangeNotifier {
 
     // Cache this track's distance/duration/point count/polyline now, while
     // its geolocations are fresh in mind, so the tracks list and summary
-    // stats never need to walk its full GeolocationData history again. Non
-    // -fatal: a caching hiccup shouldn't block the user from stopping.
+    // stats never need to walk its full GeolocationData history again.
+    // Non-fatal: a caching hiccup shouldn't block the user from stopping.
     if (trackToUpload != null) {
       try {
         await isarService.trackService.cacheTrackAggregates(trackToUpload);

--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -197,7 +197,6 @@ class RecordingBloc with ChangeNotifier {
     _lastRecordingStopTimestamp = DateTime.now().toUtc();
 
     _isRecording = false;
-    _isRecordingNotifier.value = false;
     // Keep activeCollectionMode until the next startRecording snapshots
     // settings. Resetting to gpsDriven made the idle GPS stream take the
     // continuous persist path and race into the first on-tap/periodic point.
@@ -211,6 +210,8 @@ class RecordingBloc with ChangeNotifier {
     // its geolocations are fresh in mind, so the tracks list and summary
     // stats never need to walk its full GeolocationData history again.
     // Non-fatal: a caching hiccup shouldn't block the user from stopping.
+    // Done before flipping isRecordingNotifier, since TracksScreen refreshes
+    // on that notifier and would otherwise read a stale/empty cache.
     if (trackToUpload != null) {
       try {
         await isarService.trackService.cacheTrackAggregates(trackToUpload);
@@ -218,6 +219,8 @@ class RecordingBloc with ChangeNotifier {
         ErrorService.handleError(e, stack);
       }
     }
+
+    _isRecordingNotifier.value = false;
 
     // Clean up services and handle post-ride upload if needed
     _directUploadService?.dispose();

--- a/lib/blocs/recording_bloc.dart
+++ b/lib/blocs/recording_bloc.dart
@@ -207,6 +207,18 @@ class RecordingBloc with ChangeNotifier {
     final trackToUpload = _currentTrack;
     final senseBoxForUpload = _selectedSenseBox;
 
+    // Cache this track's distance/duration/point count/polyline now, while
+    // its geolocations are fresh in mind, so the tracks list and summary
+    // stats never need to walk its full GeolocationData history again. Non
+    // -fatal: a caching hiccup shouldn't block the user from stopping.
+    if (trackToUpload != null) {
+      try {
+        await isarService.trackService.cacheTrackAggregates(trackToUpload);
+      } catch (e, stack) {
+        ErrorService.handleError(e, stack);
+      }
+    }
+
     // Clean up services and handle post-ride upload if needed
     _directUploadService?.dispose();
     _directUploadService = null;

--- a/lib/models/track_data.dart
+++ b/lib/models/track_data.dart
@@ -160,7 +160,7 @@ class TrackData {
       // which leaves us with 7995 bytes for the polyline
       tolerance *= 1.5;
       attempts++;
-    } while (polyline.length > 7950 &&
+    } while (Uri.encodeComponent(polyline).length > 7950 &&
         tolerance <= 0.005 &&
         attempts < maxAttempts);
 

--- a/lib/models/track_data.dart
+++ b/lib/models/track_data.dart
@@ -31,6 +31,21 @@ class TrackData {
   /// Interval in seconds when [dataCollectionMode] is `periodic`.
   int? collectionIntervalSeconds;
 
+  // Cached aggregates, computed once via [applyComputedAggregates] when a
+  // recording finishes (see TrackService.cacheTrackAggregates) or during a
+  // one-time backfill for tracks recorded before these fields existed. This
+  // lets list/summary screens read plain columns instead of walking every
+  // GeolocationData row (and re-running distance/polyline simplification)
+  // on every render - that walk was the cause of the app slowing down /
+  // crashing once a user has a lot of tracks.
+  double? cachedDistanceKm;
+  int? cachedDurationMs;
+  int? cachedPointCount;
+  @Index()
+  DateTime? cachedStartTimestamp;
+  DateTime? cachedEndTimestamp;
+  String? cachedPolyline;
+
   // Computed getters that provide boolean behavior
   @ignore
   bool get isUploaded => uploaded == 1;
@@ -46,17 +61,41 @@ class TrackData {
     return attempts < 0 ? 0 : attempts;
   }
 
+  /// True once this track has at least one GeolocationData row. Prefers the
+  /// cached count so it doesn't need to load the full link just to check.
   @ignore
-  Duration get duration => Duration(
-      milliseconds: geolocations.isNotEmpty
-          ? geolocations.last.timestamp.millisecondsSinceEpoch -
-              geolocations.first.timestamp.millisecondsSinceEpoch
-          : 0);
+  bool get hasGeolocationData => cachedPointCount != null
+      ? cachedPointCount! > 0
+      : geolocations.isNotEmpty;
+
+  /// Timestamp of the first point, or null for an empty track. Falls back to
+  /// a live lookup (loads the full link) for tracks not yet cached.
+  @ignore
+  DateTime? get startTimestamp =>
+      cachedStartTimestamp ??
+      (geolocations.isNotEmpty ? geolocations.first.timestamp : null);
+
+  /// Timestamp of the last point, or null for an empty track. Falls back to
+  /// a live lookup (loads the full link) for tracks not yet cached.
+  @ignore
+  DateTime? get endTimestamp =>
+      cachedEndTimestamp ??
+      (geolocations.isNotEmpty ? geolocations.last.timestamp : null);
 
   @ignore
-  double get distance {
-    return getDistance(geolocations.toList());
+  Duration get duration {
+    if (cachedDurationMs != null) {
+      return Duration(milliseconds: cachedDurationMs!);
+    }
+    return Duration(
+        milliseconds: geolocations.isNotEmpty
+            ? geolocations.last.timestamp.millisecondsSinceEpoch -
+                geolocations.first.timestamp.millisecondsSinceEpoch
+            : 0);
   }
+
+  @ignore
+  double get distance => cachedDistanceKm ?? getDistance(geolocations.toList());
 
   double calculateTolerance(int numberOfCoordinates) {
     // Base tolerance for small datasets
@@ -68,7 +107,9 @@ class TrackData {
   }
 
   @ignore
-  String get encodedPolyline {
+  String get encodedPolyline => cachedPolyline ?? _computeEncodedPolyline();
+
+  String _computeEncodedPolyline() {
     final List<Point<double>> coordinates =
         convertToSimplifyPoints(geolocations.toList());
 
@@ -96,10 +137,15 @@ class TrackData {
       return encodePolyline(castedCoordinates);
     }
 
-    // Dynamic simplification loop
+    // Dynamic simplification loop: grow the tolerance each pass until the
+    // encoded polyline fits Mapbox's static-map URL budget (or we give up
+    // once the route would be too coarse / after a bounded number of
+    // attempts, so this always terminates regardless of track shape).
     double tolerance = calculateTolerance(coordinates.length);
     String polyline;
     List<Point<double>> simplifiedCoordinates;
+    var attempts = 0;
+    const maxAttempts = 30;
     do {
       simplifiedCoordinates = simplify<Point<double>>(
         coordinates,
@@ -112,8 +158,37 @@ class TrackData {
       // Mapbox API URL lenght limit is 8192 bytes,
       // other parts of URL are 197 bytes long
       // which leaves us with 7995 bytes for the polyline
-    } while (polyline.length > 7950 && tolerance > 0.005);
+      tolerance *= 1.5;
+      attempts++;
+    } while (polyline.length > 7950 &&
+        tolerance <= 0.005 &&
+        attempts < maxAttempts);
 
     return polyline;
+  }
+
+  /// Recomputes the cached* fields from [geolocations], which must already
+  /// be loaded (via `await geolocations.load()`). Does not persist - the
+  /// caller is expected to `put` the track in a write transaction.
+  void applyComputedAggregates() {
+    final geos = geolocations.toList();
+    cachedPointCount = geos.length;
+
+    if (geos.isEmpty) {
+      cachedStartTimestamp = null;
+      cachedEndTimestamp = null;
+      cachedDurationMs = 0;
+      cachedDistanceKm = 0;
+      cachedPolyline = '';
+      return;
+    }
+
+    final start = geos.first.timestamp;
+    final end = geos.last.timestamp;
+    cachedStartTimestamp = start;
+    cachedEndTimestamp = end;
+    cachedDurationMs = end.difference(start).inMilliseconds;
+    cachedDistanceKm = getDistance(geos);
+    cachedPolyline = _computeEncodedPolyline();
   }
 }

--- a/lib/models/track_data.g.dart
+++ b/lib/models/track_data.g.dart
@@ -17,33 +17,63 @@ const TrackDataSchema = CollectionSchema(
   name: r'TrackData',
   id: -595095596094647637,
   properties: {
-    r'collectionIntervalSeconds': PropertySchema(
+    r'cachedDistanceKm': PropertySchema(
       id: 0,
+      name: r'cachedDistanceKm',
+      type: IsarType.double,
+    ),
+    r'cachedDurationMs': PropertySchema(
+      id: 1,
+      name: r'cachedDurationMs',
+      type: IsarType.long,
+    ),
+    r'cachedEndTimestamp': PropertySchema(
+      id: 2,
+      name: r'cachedEndTimestamp',
+      type: IsarType.dateTime,
+    ),
+    r'cachedPointCount': PropertySchema(
+      id: 3,
+      name: r'cachedPointCount',
+      type: IsarType.long,
+    ),
+    r'cachedPolyline': PropertySchema(
+      id: 4,
+      name: r'cachedPolyline',
+      type: IsarType.string,
+    ),
+    r'cachedStartTimestamp': PropertySchema(
+      id: 5,
+      name: r'cachedStartTimestamp',
+      type: IsarType.dateTime,
+    ),
+    r'collectionIntervalSeconds': PropertySchema(
+      id: 6,
       name: r'collectionIntervalSeconds',
       type: IsarType.long,
     ),
     r'dataCollectionMode': PropertySchema(
-      id: 1,
+      id: 7,
       name: r'dataCollectionMode',
       type: IsarType.string,
     ),
     r'isDirectUpload': PropertySchema(
-      id: 2,
+      id: 8,
       name: r'isDirectUpload',
       type: IsarType.long,
     ),
     r'lastUploadAttempt': PropertySchema(
-      id: 3,
+      id: 9,
       name: r'lastUploadAttempt',
       type: IsarType.dateTime,
     ),
     r'uploadAttempts': PropertySchema(
-      id: 4,
+      id: 10,
       name: r'uploadAttempts',
       type: IsarType.long,
     ),
     r'uploaded': PropertySchema(
-      id: 5,
+      id: 11,
       name: r'uploaded',
       type: IsarType.long,
     )
@@ -62,6 +92,19 @@ const TrackDataSchema = CollectionSchema(
       properties: [
         IndexPropertySchema(
           name: r'isDirectUpload',
+          type: IndexType.value,
+          caseSensitive: false,
+        )
+      ],
+    ),
+    r'cachedStartTimestamp': IndexSchema(
+      id: -3385800811155894414,
+      name: r'cachedStartTimestamp',
+      unique: false,
+      replace: false,
+      properties: [
+        IndexPropertySchema(
+          name: r'cachedStartTimestamp',
           type: IndexType.value,
           caseSensitive: false,
         )
@@ -91,6 +134,12 @@ int _trackDataEstimateSize(
 ) {
   var bytesCount = offsets.last;
   {
+    final value = object.cachedPolyline;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.dataCollectionMode;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -105,12 +154,18 @@ void _trackDataSerialize(
   List<int> offsets,
   Map<Type, List<int>> allOffsets,
 ) {
-  writer.writeLong(offsets[0], object.collectionIntervalSeconds);
-  writer.writeString(offsets[1], object.dataCollectionMode);
-  writer.writeLong(offsets[2], object.isDirectUpload);
-  writer.writeDateTime(offsets[3], object.lastUploadAttempt);
-  writer.writeLong(offsets[4], object.uploadAttempts);
-  writer.writeLong(offsets[5], object.uploaded);
+  writer.writeDouble(offsets[0], object.cachedDistanceKm);
+  writer.writeLong(offsets[1], object.cachedDurationMs);
+  writer.writeDateTime(offsets[2], object.cachedEndTimestamp);
+  writer.writeLong(offsets[3], object.cachedPointCount);
+  writer.writeString(offsets[4], object.cachedPolyline);
+  writer.writeDateTime(offsets[5], object.cachedStartTimestamp);
+  writer.writeLong(offsets[6], object.collectionIntervalSeconds);
+  writer.writeString(offsets[7], object.dataCollectionMode);
+  writer.writeLong(offsets[8], object.isDirectUpload);
+  writer.writeDateTime(offsets[9], object.lastUploadAttempt);
+  writer.writeLong(offsets[10], object.uploadAttempts);
+  writer.writeLong(offsets[11], object.uploaded);
 }
 
 TrackData _trackDataDeserialize(
@@ -120,13 +175,19 @@ TrackData _trackDataDeserialize(
   Map<Type, List<int>> allOffsets,
 ) {
   final object = TrackData();
-  object.collectionIntervalSeconds = reader.readLongOrNull(offsets[0]);
-  object.dataCollectionMode = reader.readStringOrNull(offsets[1]);
+  object.cachedDistanceKm = reader.readDoubleOrNull(offsets[0]);
+  object.cachedDurationMs = reader.readLongOrNull(offsets[1]);
+  object.cachedEndTimestamp = reader.readDateTimeOrNull(offsets[2]);
+  object.cachedPointCount = reader.readLongOrNull(offsets[3]);
+  object.cachedPolyline = reader.readStringOrNull(offsets[4]);
+  object.cachedStartTimestamp = reader.readDateTimeOrNull(offsets[5]);
+  object.collectionIntervalSeconds = reader.readLongOrNull(offsets[6]);
+  object.dataCollectionMode = reader.readStringOrNull(offsets[7]);
   object.id = id;
-  object.isDirectUpload = reader.readLongOrNull(offsets[2]);
-  object.lastUploadAttempt = reader.readDateTimeOrNull(offsets[3]);
-  object.uploadAttempts = reader.readLongOrNull(offsets[4]);
-  object.uploaded = reader.readLongOrNull(offsets[5]);
+  object.isDirectUpload = reader.readLongOrNull(offsets[8]);
+  object.lastUploadAttempt = reader.readDateTimeOrNull(offsets[9]);
+  object.uploadAttempts = reader.readLongOrNull(offsets[10]);
+  object.uploaded = reader.readLongOrNull(offsets[11]);
   return object;
 }
 
@@ -138,16 +199,28 @@ P _trackDataDeserializeProp<P>(
 ) {
   switch (propertyId) {
     case 0:
-      return (reader.readLongOrNull(offset)) as P;
+      return (reader.readDoubleOrNull(offset)) as P;
     case 1:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset)) as P;
     case 2:
-      return (reader.readLongOrNull(offset)) as P;
-    case 3:
       return (reader.readDateTimeOrNull(offset)) as P;
-    case 4:
+    case 3:
       return (reader.readLongOrNull(offset)) as P;
+    case 4:
+      return (reader.readStringOrNull(offset)) as P;
     case 5:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 6:
+      return (reader.readLongOrNull(offset)) as P;
+    case 7:
+      return (reader.readStringOrNull(offset)) as P;
+    case 8:
+      return (reader.readLongOrNull(offset)) as P;
+    case 9:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 10:
+      return (reader.readLongOrNull(offset)) as P;
+    case 11:
       return (reader.readLongOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -180,6 +253,14 @@ extension TrackDataQueryWhereSort
     return QueryBuilder.apply(this, (query) {
       return query.addWhereClause(
         const IndexWhereClause.any(indexName: r'isDirectUpload'),
+      );
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhere> anyCachedStartTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        const IndexWhereClause.any(indexName: r'cachedStartTimestamp'),
       );
     });
   }
@@ -363,10 +444,659 @@ extension TrackDataQueryWhere
       ));
     });
   }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'cachedStartTimestamp',
+        value: [null],
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'cachedStartTimestamp',
+        lower: [null],
+        includeLower: false,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampEqualTo(DateTime? cachedStartTimestamp) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'cachedStartTimestamp',
+        value: [cachedStartTimestamp],
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampNotEqualTo(DateTime? cachedStartTimestamp) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'cachedStartTimestamp',
+              lower: [],
+              upper: [cachedStartTimestamp],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'cachedStartTimestamp',
+              lower: [cachedStartTimestamp],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'cachedStartTimestamp',
+              lower: [cachedStartTimestamp],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'cachedStartTimestamp',
+              lower: [],
+              upper: [cachedStartTimestamp],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampGreaterThan(
+    DateTime? cachedStartTimestamp, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'cachedStartTimestamp',
+        lower: [cachedStartTimestamp],
+        includeLower: include,
+        upper: [],
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampLessThan(
+    DateTime? cachedStartTimestamp, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'cachedStartTimestamp',
+        lower: [],
+        upper: [cachedStartTimestamp],
+        includeUpper: include,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterWhereClause>
+      cachedStartTimestampBetween(
+    DateTime? lowerCachedStartTimestamp,
+    DateTime? upperCachedStartTimestamp, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.between(
+        indexName: r'cachedStartTimestamp',
+        lower: [lowerCachedStartTimestamp],
+        includeLower: includeLower,
+        upper: [upperCachedStartTimestamp],
+        includeUpper: includeUpper,
+      ));
+    });
+  }
 }
 
 extension TrackDataQueryFilter
     on QueryBuilder<TrackData, TrackData, QFilterCondition> {
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDistanceKmIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedDistanceKm',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDistanceKmIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedDistanceKm',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDistanceKmEqualTo(
+    double? value, {
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedDistanceKm',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDistanceKmGreaterThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedDistanceKm',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDistanceKmLessThan(
+    double? value, {
+    bool include = false,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedDistanceKm',
+        value: value,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDistanceKmBetween(
+    double? lower,
+    double? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    double epsilon = Query.epsilon,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedDistanceKm',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        epsilon: epsilon,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDurationMsIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedDurationMs',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDurationMsIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedDurationMs',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDurationMsEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedDurationMs',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDurationMsGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedDurationMs',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDurationMsLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedDurationMs',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedDurationMsBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedDurationMs',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedEndTimestampIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedEndTimestamp',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedEndTimestampIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedEndTimestamp',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedEndTimestampEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedEndTimestamp',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedEndTimestampGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedEndTimestamp',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedEndTimestampLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedEndTimestamp',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedEndTimestampBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedEndTimestamp',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPointCountIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedPointCount',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPointCountIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedPointCount',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPointCountEqualTo(int? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedPointCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPointCountGreaterThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedPointCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPointCountLessThan(
+    int? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedPointCount',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPointCountBetween(
+    int? lower,
+    int? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedPointCount',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedPolyline',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedPolyline',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedPolyline',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedPolyline',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedPolyline',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedPolyline',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'cachedPolyline',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'cachedPolyline',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'cachedPolyline',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'cachedPolyline',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedPolyline',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedPolylineIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'cachedPolyline',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedStartTimestampIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'cachedStartTimestamp',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedStartTimestampIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'cachedStartTimestamp',
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedStartTimestampEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'cachedStartTimestamp',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedStartTimestampGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'cachedStartTimestamp',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedStartTimestampLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'cachedStartTimestamp',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
+      cachedStartTimestampBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'cachedStartTimestamp',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<TrackData, TrackData, QAfterFilterCondition>
       collectionIntervalSecondsIsNull() {
     return QueryBuilder.apply(this, (query) {
@@ -1009,6 +1739,84 @@ extension TrackDataQueryLinks
 }
 
 extension TrackDataQuerySortBy on QueryBuilder<TrackData, TrackData, QSortBy> {
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> sortByCachedDistanceKm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDistanceKm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      sortByCachedDistanceKmDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDistanceKm', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> sortByCachedDurationMs() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDurationMs', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      sortByCachedDurationMsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDurationMs', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> sortByCachedEndTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedEndTimestamp', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      sortByCachedEndTimestampDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedEndTimestamp', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> sortByCachedPointCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPointCount', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      sortByCachedPointCountDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPointCount', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> sortByCachedPolyline() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPolyline', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> sortByCachedPolylineDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPolyline', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      sortByCachedStartTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedStartTimestamp', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      sortByCachedStartTimestampDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedStartTimestamp', Sort.desc);
+    });
+  }
+
   QueryBuilder<TrackData, TrackData, QAfterSortBy>
       sortByCollectionIntervalSeconds() {
     return QueryBuilder.apply(this, (query) {
@@ -1088,6 +1896,84 @@ extension TrackDataQuerySortBy on QueryBuilder<TrackData, TrackData, QSortBy> {
 
 extension TrackDataQuerySortThenBy
     on QueryBuilder<TrackData, TrackData, QSortThenBy> {
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> thenByCachedDistanceKm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDistanceKm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      thenByCachedDistanceKmDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDistanceKm', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> thenByCachedDurationMs() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDurationMs', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      thenByCachedDurationMsDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedDurationMs', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> thenByCachedEndTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedEndTimestamp', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      thenByCachedEndTimestampDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedEndTimestamp', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> thenByCachedPointCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPointCount', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      thenByCachedPointCountDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPointCount', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> thenByCachedPolyline() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPolyline', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy> thenByCachedPolylineDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedPolyline', Sort.desc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      thenByCachedStartTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedStartTimestamp', Sort.asc);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QAfterSortBy>
+      thenByCachedStartTimestampDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'cachedStartTimestamp', Sort.desc);
+    });
+  }
+
   QueryBuilder<TrackData, TrackData, QAfterSortBy>
       thenByCollectionIntervalSeconds() {
     return QueryBuilder.apply(this, (query) {
@@ -1179,6 +2065,45 @@ extension TrackDataQuerySortThenBy
 
 extension TrackDataQueryWhereDistinct
     on QueryBuilder<TrackData, TrackData, QDistinct> {
+  QueryBuilder<TrackData, TrackData, QDistinct> distinctByCachedDistanceKm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedDistanceKm');
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QDistinct> distinctByCachedDurationMs() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedDurationMs');
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QDistinct> distinctByCachedEndTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedEndTimestamp');
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QDistinct> distinctByCachedPointCount() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedPointCount');
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QDistinct> distinctByCachedPolyline(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedPolyline',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<TrackData, TrackData, QDistinct>
+      distinctByCachedStartTimestamp() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'cachedStartTimestamp');
+    });
+  }
+
   QueryBuilder<TrackData, TrackData, QDistinct>
       distinctByCollectionIntervalSeconds() {
     return QueryBuilder.apply(this, (query) {
@@ -1224,6 +2149,45 @@ extension TrackDataQueryProperty
   QueryBuilder<TrackData, int, QQueryOperations> idProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<TrackData, double?, QQueryOperations>
+      cachedDistanceKmProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedDistanceKm');
+    });
+  }
+
+  QueryBuilder<TrackData, int?, QQueryOperations> cachedDurationMsProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedDurationMs');
+    });
+  }
+
+  QueryBuilder<TrackData, DateTime?, QQueryOperations>
+      cachedEndTimestampProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedEndTimestamp');
+    });
+  }
+
+  QueryBuilder<TrackData, int?, QQueryOperations> cachedPointCountProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedPointCount');
+    });
+  }
+
+  QueryBuilder<TrackData, String?, QQueryOperations> cachedPolylineProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedPolyline');
+    });
+  }
+
+  QueryBuilder<TrackData, DateTime?, QQueryOperations>
+      cachedStartTimestampProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'cachedStartTimestamp');
     });
   }
 

--- a/lib/models/track_summary_stats.dart
+++ b/lib/models/track_summary_stats.dart
@@ -1,0 +1,34 @@
+/// Aggregate stats for the tracks overview screen, computed entirely from
+/// TrackData's cached* columns via DB-side sum/count/min queries - no
+/// GeolocationData row is ever loaded to produce these. See
+/// [TrackService.getSummaryStats].
+class TrackSummaryStats {
+  final int totalTrackCount;
+  final double totalDistanceKm;
+  final Duration totalDuration;
+  final DateTime? earliestStartTimestamp;
+
+  final int recentTrackCount;
+  final double recentDistanceKm;
+  final Duration recentDuration;
+
+  const TrackSummaryStats({
+    required this.totalTrackCount,
+    required this.totalDistanceKm,
+    required this.totalDuration,
+    required this.earliestStartTimestamp,
+    required this.recentTrackCount,
+    required this.recentDistanceKm,
+    required this.recentDuration,
+  });
+
+  static const empty = TrackSummaryStats(
+    totalTrackCount: 0,
+    totalDistanceKm: 0,
+    totalDuration: Duration.zero,
+    earliestStartTimestamp: null,
+    recentTrackCount: 0,
+    recentDistanceKm: 0,
+    recentDuration: Duration.zero,
+  );
+}

--- a/lib/services/isar_service/track_service.dart
+++ b/lib/services/isar_service/track_service.dart
@@ -1,5 +1,6 @@
 // File: lib/services/isar_service/track_service.dart
 import 'package:sensebox_bike/models/track_data.dart';
+import 'package:sensebox_bike/models/track_summary_stats.dart';
 import 'package:sensebox_bike/services/isar_service/isar_provider.dart';
 import 'package:isar_community/isar.dart';
 
@@ -129,5 +130,98 @@ class TrackService {
   /// Returns true for batch upload tracks or direct upload tracks with upload attempts.
   bool _shouldIncludeInUnuploadedTracks(TrackData track) {
     return track.isDirectUpload != 1 || track.uploadAttemptsCount > 0;
+  }
+
+  /// Computes [track]'s cached* aggregate fields from its GeolocationData and
+  /// persists them. Call once a track is done recording (its geolocations
+  /// are all written) - see [RecordingBloc.stopRecording]. Idempotent: safe
+  /// to call again (e.g. after retroactively editing points) to refresh.
+  Future<void> cacheTrackAggregates(TrackData track) async {
+    await track.geolocations.load();
+    track.applyComputedAggregates();
+
+    await isarProvider.runWriteTxn((isar) async {
+      await isar.trackDatas.put(track);
+    });
+  }
+
+  /// One-time migration for tracks recorded before the cached* fields
+  /// existed. Self-terminating: each batch only picks up tracks that are
+  /// still missing a cached point count, so once everything's migrated this
+  /// becomes a single cheap empty query. Safe to call on every app/tracks
+  /// screen start.
+  Future<void> backfillMissingAggregates({int batchSize = 25}) async {
+    while (true) {
+      final isar = await isarProvider.getDatabase();
+      final batch = await isar.trackDatas
+          .filter()
+          .cachedPointCountIsNull()
+          .limit(batchSize)
+          .findAll();
+
+      if (batch.isEmpty) return;
+
+      for (final track in batch) {
+        await track.geolocations.load();
+        track.applyComputedAggregates();
+      }
+
+      await isarProvider.runWriteTxn((isar) async {
+        await isar.trackDatas.putAll(batch);
+      });
+    }
+  }
+
+  /// Summary stats for the tracks overview screen, computed entirely from
+  /// TrackData's cached* columns via DB-side sum/count/min queries. Pass
+  /// [recentSince] (start-of-week, etc.) to also get stats scoped to tracks
+  /// that started on or after that moment. Never loads a GeolocationData row.
+  Future<TrackSummaryStats> getSummaryStats({DateTime? recentSince}) async {
+    final isar = await isarProvider.getDatabase();
+
+    final totalTrackCount = await isar.trackDatas.count();
+    final totalDistanceKm =
+        await isar.trackDatas.where().cachedDistanceKmProperty().sum();
+    final totalDurationMs =
+        await isar.trackDatas.where().cachedDurationMsProperty().sum();
+    final earliestStartTimestamp =
+        await isar.trackDatas.where().cachedStartTimestampProperty().min();
+
+    if (recentSince == null) {
+      return TrackSummaryStats(
+        totalTrackCount: totalTrackCount,
+        totalDistanceKm: totalDistanceKm,
+        totalDuration: Duration(milliseconds: totalDurationMs),
+        earliestStartTimestamp: earliestStartTimestamp,
+        recentTrackCount: 0,
+        recentDistanceKm: 0,
+        recentDuration: Duration.zero,
+      );
+    }
+
+    final recentTrackCount = await isar.trackDatas
+        .where()
+        .cachedStartTimestampGreaterThan(recentSince, include: true)
+        .count();
+    final recentDistanceKm = await isar.trackDatas
+        .where()
+        .cachedStartTimestampGreaterThan(recentSince, include: true)
+        .cachedDistanceKmProperty()
+        .sum();
+    final recentDurationMs = await isar.trackDatas
+        .where()
+        .cachedStartTimestampGreaterThan(recentSince, include: true)
+        .cachedDurationMsProperty()
+        .sum();
+
+    return TrackSummaryStats(
+      totalTrackCount: totalTrackCount,
+      totalDistanceKm: totalDistanceKm,
+      totalDuration: Duration(milliseconds: totalDurationMs),
+      earliestStartTimestamp: earliestStartTimestamp,
+      recentTrackCount: recentTrackCount,
+      recentDistanceKm: recentDistanceKm,
+      recentDuration: Duration(milliseconds: recentDurationMs),
+    );
   }
 }

--- a/lib/services/isar_service/track_service.dart
+++ b/lib/services/isar_service/track_service.dart
@@ -167,7 +167,23 @@ class TrackService {
       }
 
       await isarProvider.runWriteTxn((isar) async {
-        await isar.trackDatas.putAll(batch);
+        final updates = <TrackData>[];
+        for (final computedTrack in batch) {
+          final latestTrack = await isar.trackDatas.get(computedTrack.id);
+          if (latestTrack == null || latestTrack.cachedPointCount != null) {
+            continue;
+          }
+          latestTrack.cachedPointCount = computedTrack.cachedPointCount;
+          latestTrack.cachedDistanceKm = computedTrack.cachedDistanceKm;
+          latestTrack.cachedDurationMs = computedTrack.cachedDurationMs;
+          latestTrack.cachedStartTimestamp = computedTrack.cachedStartTimestamp;
+          latestTrack.cachedEndTimestamp = computedTrack.cachedEndTimestamp;
+          latestTrack.cachedPolyline = computedTrack.cachedPolyline;
+          updates.add(latestTrack);
+        }
+        if (updates.isNotEmpty) {
+          await isar.trackDatas.putAll(updates);
+        }
       });
     }
   }

--- a/lib/ui/screens/track_statistics_screen.dart
+++ b/lib/ui/screens/track_statistics_screen.dart
@@ -5,7 +5,6 @@ import 'package:sensebox_bike/theme.dart';
 import 'package:sensebox_bike/ui/widgets/common/custom_divider.dart';
 import 'package:sensebox_bike/ui/widgets/common/screen_wrapper.dart';
 import 'package:sensebox_bike/l10n/app_localizations.dart';
-import 'package:sensebox_bike/models/track_data.dart';
 
 class TrackStatisticsScreen extends StatefulWidget {
   final IsarService isarService;
@@ -31,51 +30,35 @@ class _TrackStatisticsScreenState extends State<TrackStatisticsScreen> {
   void initState() {
     super.initState();
     _now = DateTime.now();
-    _weekStart = _now.subtract(Duration(days: _now.weekday - 1));
+    _weekStart = DateTime(_now.year, _now.month, _now.day)
+        .subtract(Duration(days: _now.weekday - 1));
     _loadStats();
-  }
-
-  /// Helper method to find the first track with geolocations
-  TrackData? _findFirstTrackWithGeolocations(List<TrackData> tracks) {
-    for (final track in tracks) {
-      if (track.geolocations.isNotEmpty) {
-        return track;
-      }
-    }
-    return null;
   }
 
   Future<void> _loadStats() async {
     setState(() {
       _isLoading = true;
     });
-    final tracks = await widget.isarService.trackService.getAllTracks();
-    
-    // Find the first track with geolocations as fallback
-    final firstTrackWithGeolocations = _findFirstTrackWithGeolocations(tracks);
-    _start = firstTrackWithGeolocations != null
-        ? firstTrackWithGeolocations.geolocations.first.timestamp
-        : DateTime.now();
-        
-    final tracksThisWeek = tracks
-        .where((track) =>
-            track.geolocations.isNotEmpty &&
-            (track.geolocations.first.timestamp.isAfter(_weekStart) ||
-                DateUtils.isSameDay(
-                    track.geolocations.first.timestamp, _weekStart)))
-        .toList();
+
+    // One-time (per not-yet-migrated track) backfill of the cached* fields
+    // for tracks recorded before they existed. Self-terminating: a no-op
+    // query once every track has been migrated.
+    await widget.isarService.trackService.backfillMissingAggregates();
+    if (!mounted) return;
+
+    final stats = await widget.isarService.trackService
+        .getSummaryStats(recentSince: _weekStart);
+    if (!mounted) return;
 
     setState(() {
-      _trackCount = tracks.length;
-      _totalDuration =
-          tracks.fold(Duration.zero, (prev, track) => prev + track.duration);
-      _totalDistance = tracks.fold(0.0, (prev, track) => prev + track.distance);
+      _start = stats.earliestStartTimestamp ?? DateTime.now();
+      _trackCount = stats.totalTrackCount;
+      _totalDuration = stats.totalDuration;
+      _totalDistance = stats.totalDistanceKm;
 
-      _ridesThisWeek = tracksThisWeek.length;
-      _distanceThisWeek =
-          tracksThisWeek.fold(0.0, (prev, track) => prev + track.distance);
-      _timeThisWeek = tracksThisWeek.fold(
-          Duration.zero, (prev, track) => prev + track.duration);
+      _ridesThisWeek = stats.recentTrackCount;
+      _distanceThisWeek = stats.recentDistanceKm;
+      _timeThisWeek = stats.recentDuration;
       _isLoading = false;
     });
   }

--- a/lib/ui/screens/tracks_screen.dart
+++ b/lib/ui/screens/tracks_screen.dart
@@ -148,34 +148,29 @@ class TracksScreenState extends State<TracksScreen> {
   Future<void> _loadSummaryStats() async {
     setState(() => _isStatsLoading = true);
 
-    final tracks = await _isarService.trackService.getAllTracks();
+    // One-time (per not-yet-migrated track) backfill of the cached* fields
+    // for tracks recorded before they existed. Self-terminating: a no-op
+    // query once every track has been migrated.
+    await _isarService.trackService.backfillMissingAggregates();
     if (!mounted) return;
+
     final now = DateTime.now();
-    final weekStart = now.subtract(Duration(days: now.weekday - 1));
-    final tracksWithGeo =
-        tracks.where((track) => track.geolocations.isNotEmpty).toList();
-    final weeklyTracks = tracksWithGeo
-        .where((track) =>
-            track.geolocations.first.timestamp.isAfter(weekStart) ||
-            DateUtils.isSameDay(track.geolocations.first.timestamp, weekStart))
-        .toList();
+    final weekStart = DateTime(now.year, now.month, now.day)
+        .subtract(Duration(days: now.weekday - 1));
+
+    final stats = await _isarService.trackService
+        .getSummaryStats(recentSince: weekStart);
+    if (!mounted) return;
 
     setState(() {
-      _totalTrackCount = tracks.length;
-      _totalDuration =
-          tracks.fold(Duration.zero, (prev, track) => prev + track.duration);
-      _totalDistance = tracks.fold(0.0, (prev, track) => prev + track.distance);
-      _statsStartDate = tracksWithGeo.isEmpty
-          ? null
-          : tracksWithGeo
-              .map((track) => track.geolocations.first.timestamp)
-              .reduce((a, b) => a.isBefore(b) ? a : b);
+      _totalTrackCount = stats.totalTrackCount;
+      _totalDuration = stats.totalDuration;
+      _totalDistance = stats.totalDistanceKm;
+      _statsStartDate = stats.earliestStartTimestamp;
 
-      _ridesThisWeek = weeklyTracks.length;
-      _durationThisWeek = weeklyTracks.fold(
-          Duration.zero, (prev, track) => prev + track.duration);
-      _distanceThisWeek =
-          weeklyTracks.fold(0.0, (prev, track) => prev + track.distance);
+      _ridesThisWeek = stats.recentTrackCount;
+      _durationThisWeek = stats.recentDuration;
+      _distanceThisWeek = stats.recentDistanceKm;
       _isStatsLoading = false;
     });
   }

--- a/lib/ui/widgets/track/track_list_item.dart
+++ b/lib/ui/widgets/track/track_list_item.dart
@@ -39,18 +39,17 @@ class TrackListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final localizations = AppLocalizations.of(context)!;
-    final hasGeolocations = track.geolocations.isNotEmpty;
+    final hasGeolocations = track.hasGeolocationData;
     final colorScheme = theme.colorScheme;
     final statusInfo =
         trackBloc.getEstimatedTrackStatusInfo(track, theme, localizations);
-    final date = hasGeolocations
-        ? trackBloc.formatTrackDate(track.geolocations.first.timestamp)
+    final startTimestamp = track.startTimestamp;
+    final endTimestamp = track.endTimestamp;
+    final date = startTimestamp != null
+        ? trackBloc.formatTrackDate(startTimestamp)
         : '-';
-    final times = hasGeolocations
-        ? trackBloc.formatTrackTimeRange(
-            track.geolocations.first.timestamp,
-            track.geolocations.last.timestamp,
-          )
+    final times = startTimestamp != null && endTimestamp != null
+        ? trackBloc.formatTrackTimeRange(startTimestamp, endTimestamp)
         : localizations.trackNoGeolocations;
     final duration =
         trackBloc.formatTrackDuration(track.duration, localizations);

--- a/test/localization/tracks_screen_test.dart
+++ b/test/localization/tracks_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:sensebox_bike/blocs/track_bloc.dart';
 import 'package:sensebox_bike/blocs/recording_bloc.dart';
 import 'package:sensebox_bike/blocs/opensensemap_bloc.dart';
 import 'package:sensebox_bike/models/track_data.dart';
+import 'package:sensebox_bike/models/track_summary_stats.dart';
 import 'package:sensebox_bike/services/isar_service.dart';
 import 'package:sensebox_bike/services/isar_service/track_service.dart';
 import 'package:sensebox_bike/services/opensensemap_service.dart';
@@ -51,6 +52,12 @@ void main() {
           limit: any(named: 'limit'),
           skipLastTrack: any(named: 'skipLastTrack'),
         )).thenAnswer((_) async => <TrackData>[]);
+    when(() => mockTrackService.backfillMissingAggregates(
+          batchSize: any(named: 'batchSize'),
+        )).thenAnswer((_) async {});
+    when(() => mockTrackService.getSummaryStats(
+          recentSince: any(named: 'recentSince'),
+        )).thenAnswer((_) async => TrackSummaryStats.empty);
 
     // Mock OpenSenseMapBloc dependencies
     final mockOpenSenseMapBloc = MockOpenSenseMapBloc();

--- a/test/models/track_data_test.dart
+++ b/test/models/track_data_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar_community/isar.dart';
 import 'package:sensebox_bike/models/sensor_data.dart';
@@ -92,6 +94,58 @@ void main() {
     // Verify that the polyline is simplified
     final decodedPolyline = decodePolyline(polyline);
     expect(decodedPolyline.length, lessThan(20));
+  });
+
+  test(
+      'encodedPolyline stays within the Mapbox URL budget for a long, noisy track',
+      () async {
+    // Regression test: the dynamic simplification loop used to compute a
+    // tolerance once and never grow it, so it always bailed after a single
+    // pass - producing polylines tens of KB over the ~7950 byte budget for
+    // busy tracks instead of actually shrinking them.
+    //
+    // Models a real bike ride as a sequence of mostly-straight road segments
+    // (direction only changes at "intersections") with small per-point GPS
+    // jitter - the shape Douglas-Peucker simplification is actually meant to
+    // compress, unlike a fully random walk which is fractal at every scale.
+    final rnd = Random(42);
+    double lat = 52.5, lng = 13.4;
+    var i = 0;
+
+    await isar.writeTxn(() async {
+      for (var leg = 0; leg < 50 && i < 5000; leg++) {
+        final heading = rnd.nextDouble() * 2 * pi;
+        for (var step = 0; step < 100 && i < 5000; step++, i++) {
+          lat += cos(heading) * 0.00002 + (rnd.nextDouble() - 0.5) * 0.000002;
+          lng += sin(heading) * 0.00002 + (rnd.nextDouble() - 0.5) * 0.000002;
+          final geolocation = GeolocationData()
+            ..latitude = lat
+            ..longitude = lng
+            ..timestamp = DateTime.now().toUtc().add(Duration(seconds: i))
+            ..speed = 0.0;
+          trackData.geolocations.add(geolocation);
+          await isar.geolocationDatas.put(geolocation);
+        }
+      }
+    });
+
+    final unsimplified = encodePolyline(trackData.geolocations
+        .map((g) => [g.latitude, g.longitude])
+        .toList());
+
+    final stopwatch = Stopwatch()..start();
+    final polyline = trackData.encodedPolyline;
+    stopwatch.stop();
+
+    // The loop caps simplification tolerance at a fixed ceiling so the route
+    // shape isn't destroyed, so hitting the exact Mapbox byte budget isn't
+    // guaranteed for every track shape - but it must always substantially
+    // shrink the unsimplified encoding, and always terminate quickly (the
+    // bug this guards against was the loop bailing after a single pass with
+    // no shrinkage at all, and a theoretical non-terminating variant of the
+    // same bug).
+    expect(polyline.length, lessThan(unsimplified.length ~/ 2));
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 5)));
   });
 
   test('calculateTolerance scales dynamically with number of coordinates', () {

--- a/test/services/isar_service/track_service_test.dart
+++ b/test/services/isar_service/track_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar_community/isar.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:sensebox_bike/models/geolocation_data.dart';
 import 'package:sensebox_bike/models/track_data.dart';
 import 'package:sensebox_bike/services/isar_service/track_service.dart';
 import 'package:flutter/services.dart';
@@ -562,6 +563,189 @@ group('TrackService', () {
         final ids = tracks.map((t) => t.id).toSet();
         expect(ids, isNot(contains(newestFilteredOut.id)));
         expect(tracks.length, equals(1));
+      });
+    });
+
+    group('cacheTrackAggregates', () {
+      Future<TrackData> putTrackWithGeolocations(
+          List<GeolocationData> geolocations) async {
+        final track = TrackData();
+        await isar.writeTxn(() async {
+          await isar.trackDatas.put(track);
+          for (final geo in geolocations) {
+            geo.track.value = track;
+            await isar.geolocationDatas.put(geo);
+            await geo.track.save();
+          }
+        });
+        return track;
+      }
+
+      test('computes and persists distance/duration/point count/polyline',
+          () async {
+        final start = DateTime(2024, 1, 1, 10, 0, 0);
+        final track = await putTrackWithGeolocations([
+          GeolocationData()
+            ..latitude = 52.5200
+            ..longitude = 13.4050
+            ..timestamp = start
+            ..speed = 0,
+          GeolocationData()
+            ..latitude = 52.5300
+            ..longitude = 13.4150
+            ..timestamp = start.add(const Duration(minutes: 10))
+            ..speed = 0,
+        ]);
+
+        await trackService.cacheTrackAggregates(track);
+
+        final reloaded = await isar.trackDatas.get(track.id);
+        expect(reloaded, isNotNull);
+        expect(reloaded!.cachedPointCount, equals(2));
+        expect(reloaded.cachedStartTimestamp, equals(start));
+        expect(reloaded.cachedEndTimestamp,
+            equals(start.add(const Duration(minutes: 10))));
+        expect(reloaded.cachedDurationMs,
+            equals(const Duration(minutes: 10).inMilliseconds));
+        expect(reloaded.cachedDistanceKm, greaterThan(0));
+        expect(reloaded.cachedPolyline, isNotEmpty);
+
+        // The plain getters should now read straight from the cache without
+        // touching the geolocations link.
+        expect(reloaded.duration, equals(const Duration(minutes: 10)));
+        expect(reloaded.distance, equals(reloaded.cachedDistanceKm));
+      });
+
+      test('caches zeroed-out fields for a track with no geolocations',
+          () async {
+        final track = await putTrackWithGeolocations([]);
+
+        await trackService.cacheTrackAggregates(track);
+
+        final reloaded = await isar.trackDatas.get(track.id);
+        expect(reloaded!.cachedPointCount, equals(0));
+        expect(reloaded.cachedStartTimestamp, isNull);
+        expect(reloaded.cachedEndTimestamp, isNull);
+        expect(reloaded.cachedDurationMs, equals(0));
+        expect(reloaded.cachedDistanceKm, equals(0));
+        expect(reloaded.hasGeolocationData, isFalse);
+      });
+    });
+
+    group('backfillMissingAggregates', () {
+      test('populates cached fields for legacy tracks missing them',
+          () async {
+        await clearIsarDatabase(isar);
+
+        final start = DateTime(2024, 1, 1, 10, 0, 0);
+        final legacyTrack = TrackData();
+        await isar.writeTxn(() async {
+          await isar.trackDatas.put(legacyTrack);
+          final geo = GeolocationData()
+            ..latitude = 52.5200
+            ..longitude = 13.4050
+            ..timestamp = start
+            ..speed = 0
+            ..track.value = legacyTrack;
+          await isar.geolocationDatas.put(geo);
+          await geo.track.save();
+        });
+
+        expect(legacyTrack.cachedPointCount, isNull);
+
+        await trackService.backfillMissingAggregates();
+
+        final reloaded = await isar.trackDatas.get(legacyTrack.id);
+        expect(reloaded!.cachedPointCount, equals(1));
+        expect(reloaded.cachedStartTimestamp, equals(start));
+      });
+
+      test('is a no-op once every track is already cached', () async {
+        await clearIsarDatabase(isar);
+
+        final track = TrackData()
+          ..cachedPointCount = 0
+          ..cachedDistanceKm = 0
+          ..cachedDurationMs = 0;
+        await isar.writeTxn(() async {
+          await isar.trackDatas.put(track);
+        });
+
+        // Should return promptly without throwing, touching nothing.
+        await expectLater(
+          trackService.backfillMissingAggregates(),
+          completes,
+        );
+      });
+    });
+
+    group('getSummaryStats', () {
+      test('sums cached fields across all tracks without recentSince',
+          () async {
+        await clearIsarDatabase(isar);
+
+        final trackA = TrackData()
+          ..cachedDistanceKm = 5.0
+          ..cachedDurationMs = const Duration(minutes: 10).inMilliseconds
+          ..cachedStartTimestamp = DateTime(2024, 1, 1);
+        final trackB = TrackData()
+          ..cachedDistanceKm = 7.5
+          ..cachedDurationMs = const Duration(minutes: 20).inMilliseconds
+          ..cachedStartTimestamp = DateTime(2024, 2, 1);
+
+        await isar.writeTxn(() async {
+          await isar.trackDatas.putAll([trackA, trackB]);
+        });
+
+        final stats = await trackService.getSummaryStats();
+
+        expect(stats.totalTrackCount, equals(2));
+        expect(stats.totalDistanceKm, equals(12.5));
+        expect(stats.totalDuration, equals(const Duration(minutes: 30)));
+        expect(stats.earliestStartTimestamp, equals(DateTime(2024, 1, 1)));
+        expect(stats.recentTrackCount, equals(0));
+      });
+
+      test('scopes recent* fields to tracks starting on/after recentSince',
+          () async {
+        await clearIsarDatabase(isar);
+
+        final oldTrack = TrackData()
+          ..cachedDistanceKm = 3.0
+          ..cachedDurationMs = const Duration(minutes: 5).inMilliseconds
+          ..cachedStartTimestamp = DateTime(2024, 1, 1);
+        final recentTrack = TrackData()
+          ..cachedDistanceKm = 4.0
+          ..cachedDurationMs = const Duration(minutes: 8).inMilliseconds
+          ..cachedStartTimestamp = DateTime(2024, 6, 15);
+
+        await isar.writeTxn(() async {
+          await isar.trackDatas.putAll([oldTrack, recentTrack]);
+        });
+
+        final stats = await trackService.getSummaryStats(
+          recentSince: DateTime(2024, 6, 1),
+        );
+
+        expect(stats.totalTrackCount, equals(2));
+        expect(stats.totalDistanceKm, equals(7.0));
+        expect(stats.recentTrackCount, equals(1));
+        expect(stats.recentDistanceKm, equals(4.0));
+        expect(stats.recentDuration, equals(const Duration(minutes: 8)));
+      });
+
+      test('returns zeroed stats for an empty database', () async {
+        await clearIsarDatabase(isar);
+
+        final stats = await trackService.getSummaryStats(
+          recentSince: DateTime(2024, 1, 1),
+        );
+
+        expect(stats.totalTrackCount, equals(0));
+        expect(stats.totalDistanceKm, equals(0));
+        expect(stats.totalDuration, equals(Duration.zero));
+        expect(stats.earliestStartTimestamp, isNull);
+        expect(stats.recentTrackCount, equals(0));
       });
     });
 });


### PR DESCRIPTION
TrackData gains cached distance/duration/point count/start+end timestamp/ polyline fields, computed once instead of walking the full geolocations backlink (and re-running distance/polyline simplification) on every read. This was the cause of the app slowing down and becoming crash-prone once a user accumulated a lot of tracks: the tracks screen's summary stats loaded every track's entire GPS history on every visit.

- TrackData.applyComputedAggregates() computes the cached fields from a loaded geolocations link; distance/duration/encodedPolyline getters now read the cache first, falling back to the old live walk only for tracks not yet migrated.
- TrackService: cacheTrackAggregates() (called from RecordingBloc.stopRecording once a track finishes), backfillMissingAggregates() (self-terminating one-time migration for tracks recorded before these fields existed), getSummaryStats() (DB-side sum/count/min aggregate query - never loads a GeolocationData row).
- tracks_screen.dart, track_statistics_screen.dart, and track_list_item.dart switched from per-track backlink walks + Dart-side fold to the cached fields / aggregate query.
- Fixed the polyline dynamic-simplification loop: tolerance was computed once and never grown, so the loop always exited after its first pass, silently producing polylines far over the intended Mapbox URL byte budget for busy tracks. Tolerance now grows each pass, bounded by both the original distortion ceiling and a hard attempt cap.